### PR TITLE
feat: add HTTPRoute support based on GATEWAY_SYSTEM_TYPE

### DIFF
--- a/entity/httproute.go
+++ b/entity/httproute.go
@@ -12,6 +12,6 @@ func (r HttpRoute) GetMetadata() Metadata {
 	return *FromObjectMeta(r.Kind, &r.ObjectMeta)
 }
 
-func RouteFromHTTPRoute(httpRoute *v1.HTTPRoute) *HttpRoute {
+func WrapHTTPRoute(httpRoute *v1.HTTPRoute) *HttpRoute {
 	return &HttpRoute{httpRoute}
 }

--- a/entity/httproute_test.go
+++ b/entity/httproute_test.go
@@ -36,7 +36,7 @@ func TestHttpRoute_GetMetadata(t *testing.T) {
 	assert.Equal(t, "test route", metadata.Annotations["description"])
 }
 
-func TestRouteFromHTTPRoute(t *testing.T) {
+func TestWrapHTTPRoute(t *testing.T) {
 	httpRoute := &v1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-http-route",
@@ -44,7 +44,7 @@ func TestRouteFromHTTPRoute(t *testing.T) {
 		},
 	}
 
-	result := RouteFromHTTPRoute(httpRoute)
+	result := WrapHTTPRoute(httpRoute)
 
 	assert.NotNil(t, result)
 	assert.Equal(t, httpRoute, result.HTTPRoute)
@@ -52,8 +52,8 @@ func TestRouteFromHTTPRoute(t *testing.T) {
 	assert.Equal(t, "test-namespace", result.Namespace)
 }
 
-func TestRouteFromHTTPRoute_NilInput(t *testing.T) {
-	result := RouteFromHTTPRoute(nil)
+func TestWrapHTTPRoute_NilInput(t *testing.T) {
+	result := WrapHTTPRoute(nil)
 
 	assert.NotNil(t, result)
 	assert.Nil(t, result.HTTPRoute)

--- a/entity/route.go
+++ b/entity/route.go
@@ -363,31 +363,23 @@ func buildSessionPersistence(annotations map[string]string) *gatewayv1.SessionPe
 }
 
 func buildTimeouts(annotations map[string]string) *gatewayv1.HTTPRouteTimeouts {
-	var hasTimeouts bool
-	timeoutKeys := []string{
-		"nginx.ingress.kubernetes.io/proxy-read-timeout",
-		"nginx.ingress.kubernetes.io/proxy-send-timeout",
-		"nginx.ingress.kubernetes.io/proxy-connect-timeout",
-	}
-	for _, key := range timeoutKeys {
-		if _, exists := annotations[key]; exists {
-			hasTimeouts = true
-			break
-		}
+	if connectTimeout, exists := annotations[AnnotationProxyConnectTimeout]; exists && connectTimeout != "" {
+		logger.Warn("annotation %s=%s requires BackendTrafficPolicy and is not applied to HTTPRoute", AnnotationProxyConnectTimeout, connectTimeout)
 	}
 
-	if !hasTimeouts {
+	requestTimeoutValue := ""
+	if readTimeout, exists := annotations[AnnotationProxyReadTimeout]; exists && readTimeout != "" {
+		requestTimeoutValue = readTimeout
+	} else if sendTimeout, exists := annotations[AnnotationProxySendTimeout]; exists && sendTimeout != "" {
+		requestTimeoutValue = sendTimeout
+	}
+
+	if requestTimeoutValue == "" {
 		return nil
 	}
 
-	timeouts := &gatewayv1.HTTPRouteTimeouts{}
-
-	if readTimeout, exists := annotations[AnnotationProxyReadTimeout]; exists && readTimeout != "" {
-		timeout := gatewayv1.Duration(readTimeout + "s")
-		timeouts.Request = &timeout
-	}
-
-	return timeouts
+	timeout := gatewayv1.Duration(requestTimeoutValue + "s")
+	return &gatewayv1.HTTPRouteTimeouts{Request: &timeout}
 }
 
 func RouteFromHTTPRouteGatewayV1(httpRoute *gatewayv1.HTTPRoute) *Route {

--- a/entity/route.go
+++ b/entity/route.go
@@ -363,14 +363,14 @@ func buildSessionPersistence(annotations map[string]string) *gatewayv1.SessionPe
 }
 
 func buildTimeouts(annotations map[string]string) *gatewayv1.HTTPRouteTimeouts {
-	if connectTimeout, exists := annotations[AnnotationProxyConnectTimeout]; exists && connectTimeout != "" {
+	if connectTimeout := annotations[AnnotationProxyConnectTimeout]; connectTimeout != "" {
 		logger.Warn("annotation %s=%s requires BackendTrafficPolicy and is not applied to HTTPRoute", AnnotationProxyConnectTimeout, connectTimeout)
 	}
 
 	requestTimeoutValue := ""
-	if readTimeout, exists := annotations[AnnotationProxyReadTimeout]; exists && readTimeout != "" {
+	if readTimeout := annotations[AnnotationProxyReadTimeout]; readTimeout != "" {
 		requestTimeoutValue = readTimeout
-	} else if sendTimeout, exists := annotations[AnnotationProxySendTimeout]; exists && sendTimeout != "" {
+	} else if sendTimeout := annotations[AnnotationProxySendTimeout]; sendTimeout != "" {
 		requestTimeoutValue = sendTimeout
 	}
 

--- a/entity/route.go
+++ b/entity/route.go
@@ -382,8 +382,8 @@ func buildTimeouts(annotations map[string]string) *gatewayv1.HTTPRouteTimeouts {
 	return &gatewayv1.HTTPRouteTimeouts{Request: &timeout}
 }
 
-func RouteFromHTTPRouteGatewayV1(httpRoute *gatewayv1.HTTPRoute) *Route {
-	logger.Debugf("Processing RouteFromHTTPRouteGatewayV1, httpRoute: %s", httpRoute.Name)
+func RouteFromHTTPRoute(httpRoute *gatewayv1.HTTPRoute) *Route {
+	logger.Debugf("Processing RouteFromHTTPRoute, httpRoute: %s", httpRoute.Name)
 
 	var routeSpec RouteSpec
 	if len(httpRoute.Spec.Rules) > 0 &&

--- a/entity/route.go
+++ b/entity/route.go
@@ -6,6 +6,7 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	networkingV1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 var logger = logging.GetLogger("entity_route")
@@ -237,4 +238,240 @@ func NewRouteFromInterface(object any) *Route {
 
 func (route Route) GetMetadata() Metadata {
 	return route.Metadata
+}
+
+func (route Route) ToHTTPRoute(gatewayNamespace, gatewayName string) *gatewayv1.HTTPRoute {
+	httpRoute := &gatewayv1.HTTPRoute{
+		ObjectMeta: *route.Metadata.ToObjectMeta(),
+	}
+
+	annotations := route.Metadata.Annotations
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	ns := gatewayv1.Namespace(gatewayNamespace)
+	httpRoute.Spec.ParentRefs = []gatewayv1.ParentReference{
+		{
+			Name:      gatewayv1.ObjectName(gatewayName),
+			Namespace: &ns,
+		},
+	}
+
+	httpRoute.Spec.Hostnames = []gatewayv1.Hostname{gatewayv1.Hostname(route.Spec.Host)}
+
+	pathType := gatewayv1.PathMatchPathPrefix
+	if route.Spec.PathType != "" {
+		switch route.Spec.PathType {
+		case "Exact":
+			pathType = gatewayv1.PathMatchExact
+		case "Prefix", "ImplementationSpecific":
+			pathType = gatewayv1.PathMatchPathPrefix
+		default:
+			pathType = gatewayv1.PathMatchPathPrefix
+		}
+	}
+
+	path := route.Spec.Path
+	if path == "" {
+		path = "/"
+	}
+
+	port := gatewayv1.PortNumber(route.Spec.Port.TargetPort)
+	if port == 0 {
+		port = 8080
+	}
+
+	var filters []gatewayv1.HTTPRouteFilter
+
+	if enableCors, exists := annotations["nginx.ingress.kubernetes.io/enable-cors"]; exists && enableCors == "true" {
+		corsFilter := buildCORSFilter(annotations)
+		if corsFilter != nil {
+			filters = append(filters, *corsFilter)
+		}
+	}
+
+	if snippet, exists := annotations["nginx.ingress.kubernetes.io/configuration-snippet"]; exists && snippet != "" {
+		logger.Warn("Ingress annotation 'configuration-snippet' found but cannot be automatically converted to HTTPRoute. " +
+			"Manual conversion required using RequestHeaderModifier/ResponseHeaderModifier filters. See GatewayAPIMigration.md section 6")
+	}
+
+	rule := gatewayv1.HTTPRouteRule{
+		Matches: []gatewayv1.HTTPRouteMatch{
+			{
+				Path: &gatewayv1.HTTPPathMatch{
+					Type:  &pathType,
+					Value: &path,
+				},
+			},
+		},
+		BackendRefs: []gatewayv1.HTTPBackendRef{
+			{
+				BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name: gatewayv1.ObjectName(route.Spec.Service.Name),
+						Port: &port,
+					},
+				},
+			},
+		},
+	}
+
+	if len(filters) > 0 {
+		rule.Filters = filters
+	}
+
+	if affinity, exists := annotations["nginx.ingress.kubernetes.io/affinity"]; exists && affinity == "cookie" {
+		sessionPersistence := buildSessionPersistence(annotations)
+		if sessionPersistence != nil {
+			rule.SessionPersistence = sessionPersistence
+		}
+	}
+
+	if timeouts := buildTimeouts(annotations); timeouts != nil {
+		rule.Timeouts = timeouts
+	}
+
+	httpRoute.Spec.Rules = []gatewayv1.HTTPRouteRule{rule}
+
+	logAdditionalResourceWarnings(annotations, route.Metadata.Name)
+
+	return httpRoute
+}
+
+func buildCORSFilter(annotations map[string]string) *gatewayv1.HTTPRouteFilter {
+
+	logger.Warn("CORS annotation detected. Note: CORS configuration in HTTPRoute may differ between Gateway API implementations. " +
+		"See GatewayAPIMigration.md section 8 for manual configuration")
+
+	return nil
+}
+
+func buildSessionPersistence(annotations map[string]string) *gatewayv1.SessionPersistence {
+	persistenceType := gatewayv1.CookieBasedSessionPersistence
+	sessionPersistence := &gatewayv1.SessionPersistence{
+		Type: &persistenceType,
+	}
+
+	if cookieName, exists := annotations["nginx.ingress.kubernetes.io/session-cookie-name"]; exists && cookieName != "" {
+		sessionPersistence.SessionName = &cookieName
+	}
+
+	if maxAge, exists := annotations["nginx.ingress.kubernetes.io/session-cookie-max-age"]; exists && maxAge != "" {
+		timeout := gatewayv1.Duration(maxAge + "s")
+		sessionPersistence.AbsoluteTimeout = &timeout
+	}
+
+	return sessionPersistence
+}
+
+func buildTimeouts(annotations map[string]string) *gatewayv1.HTTPRouteTimeouts {
+	var hasTimeouts bool
+	timeoutKeys := []string{
+		"nginx.ingress.kubernetes.io/proxy-read-timeout",
+		"nginx.ingress.kubernetes.io/proxy-send-timeout",
+		"nginx.ingress.kubernetes.io/proxy-connect-timeout",
+	}
+	for _, key := range timeoutKeys {
+		if _, exists := annotations[key]; exists {
+			hasTimeouts = true
+			break
+		}
+	}
+
+	if !hasTimeouts {
+		return nil
+	}
+
+	timeouts := &gatewayv1.HTTPRouteTimeouts{}
+
+	if readTimeout, exists := annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"]; exists && readTimeout != "" {
+		timeout := gatewayv1.Duration(readTimeout + "s")
+		timeouts.Request = &timeout
+	}
+
+	return timeouts
+}
+
+func logAdditionalResourceWarnings(annotations map[string]string, routeName string) {
+	if protocol, exists := annotations["nginx.ingress.kubernetes.io/backend-protocol"]; exists && protocol == "HTTPS" {
+		logger.Warn("Route '%s': Ingress annotation 'backend-protocol: HTTPS' requires BackendTLSPolicy resource. "+
+			"See GatewayAPIMigration.md section 5", routeName)
+	}
+	if _, exists := annotations["nginx.ingress.kubernetes.io/secure-backends"]; exists {
+		logger.Warn("Route '%s': Ingress annotation 'secure-backends' requires BackendTLSPolicy resource. "+
+			"See GatewayAPIMigration.md section 5", routeName)
+	}
+
+	if protocol, exists := annotations["nginx.ingress.kubernetes.io/backend-protocol"]; exists && protocol == "GRPC" {
+		logger.Warn("Route '%s': Ingress annotation 'backend-protocol: GRPC' requires BackendTrafficPolicy resource with useClientProtocol. "+
+			"See GatewayAPIMigration.md section 8", routeName)
+	}
+
+	if _, exists := annotations["nginx.ingress.kubernetes.io/proxy-connect-timeout"]; exists {
+		logger.Warn("Route '%s': Ingress annotation 'proxy-connect-timeout' requires BackendTrafficPolicy resource. "+
+			"See GatewayAPIMigration.md section 9", routeName)
+	}
+
+	if _, exists := annotations["nginx.ingress.kubernetes.io/auth-type"]; exists {
+		logger.Warn("Route '%s': Ingress annotation 'auth-type' requires SecurityPolicy resource. "+
+			"See GatewayAPIMigration.md section 13", routeName)
+	}
+
+	if passthrough, exists := annotations["nginx.ingress.kubernetes.io/ssl-passthrough"]; exists && passthrough == "true" {
+		logger.Warn("Route '%s': Ingress annotation 'ssl-passthrough' requires TLSRoute resource instead of HTTPRoute. "+
+			"See GatewayAPIMigration.md section 12", routeName)
+	}
+
+	if _, exists := annotations["nginx.ingress.kubernetes.io/app-root"]; exists {
+		logger.Warn("Route '%s': Ingress annotation 'app-root' requires additional HTTPRoute rule with RequestRedirect filter. "+
+			"See GatewayAPIMigration.md section 7", routeName)
+	}
+}
+
+func RouteFromHTTPRouteGatewayV1(httpRoute *gatewayv1.HTTPRoute) *Route {
+	logger.Debugf("Processing RouteFromHTTPRouteGatewayV1, httpRoute: %s", httpRoute.Name)
+	metadata := *FromObjectMeta("Route", &httpRoute.ObjectMeta)
+
+	var routeSpec RouteSpec
+	if len(httpRoute.Spec.Rules) > 0 &&
+		len(httpRoute.Spec.Rules[0].BackendRefs) > 0 &&
+		len(httpRoute.Spec.Rules[0].Matches) > 0 {
+
+		backendRef := httpRoute.Spec.Rules[0].BackendRefs[0]
+		match := httpRoute.Spec.Rules[0].Matches[0]
+
+		target := Target{Name: string(backendRef.Name)}
+
+		var port int32
+		if backendRef.Port != nil {
+			port = int32(*backendRef.Port)
+		}
+
+		var pathType string
+		var path string
+		if match.Path != nil {
+			if match.Path.Type != nil {
+				pathType = string(*match.Path.Type)
+			}
+			if match.Path.Value != nil {
+				path = *match.Path.Value
+			}
+		}
+
+		var host string
+		if len(httpRoute.Spec.Hostnames) > 0 {
+			host = string(httpRoute.Spec.Hostnames[0])
+		}
+
+		routeSpec = RouteSpec{
+			Service:  target,
+			Port:     RoutePort{TargetPort: port},
+			PathType: pathType,
+			Path:     path,
+			Host:     host,
+		}
+	}
+
+	return &Route{Spec: routeSpec, Metadata: metadata}
 }

--- a/entity/route.go
+++ b/entity/route.go
@@ -278,17 +278,10 @@ func normalizeRouteAnnotations(annotations map[string]string) map[string]string 
 }
 
 func pathMatchTypeFromRoute(pathType string) gatewayv1.PathMatchType {
-	if pathType == "" {
-		return gatewayv1.PathMatchPathPrefix
-	}
-	switch pathType {
-	case "Exact":
+	if pathType == "Exact" {
 		return gatewayv1.PathMatchExact
-	case "Prefix", "ImplementationSpecific":
-		return gatewayv1.PathMatchPathPrefix
-	default:
-		return gatewayv1.PathMatchPathPrefix
 	}
+	return gatewayv1.PathMatchPathPrefix
 }
 
 func routePathValue(path string) string {

--- a/entity/route.go
+++ b/entity/route.go
@@ -11,6 +11,15 @@ import (
 
 var logger = logging.GetLogger("entity_route")
 
+const (
+	AnnotationAffinity            = "nginx.ingress.kubernetes.io/affinity"
+	AnnotationSessionCookieName   = "nginx.ingress.kubernetes.io/session-cookie-name"
+	AnnotationSessionCookieMaxAge = "nginx.ingress.kubernetes.io/session-cookie-max-age"
+	AnnotationProxyReadTimeout    = "nginx.ingress.kubernetes.io/proxy-read-timeout"
+	AnnotationProxySendTimeout    = "nginx.ingress.kubernetes.io/proxy-send-timeout"
+	AnnotationProxyConnectTimeout = "nginx.ingress.kubernetes.io/proxy-connect-timeout"
+)
+
 type (
 	// todo change to Ingress in next major release AND REWRITE entity to comply with Ingress structure!
 	Route struct {
@@ -258,8 +267,6 @@ func (route Route) ToHTTPRoute(gatewayNamespace, gatewayName string) *gatewayv1.
 	httpRoute.Spec.Hostnames = []gatewayv1.Hostname{gatewayv1.Hostname(route.Spec.Host)}
 	httpRoute.Spec.Rules = []gatewayv1.HTTPRouteRule{buildHTTPRouteRule(route, annotations)}
 
-	logAdditionalResourceWarnings(annotations, route.Metadata.Name)
-
 	return httpRoute
 }
 
@@ -298,27 +305,10 @@ func routeBackendPort(targetPort int32) gatewayv1.PortNumber {
 	return gatewayv1.PortNumber(targetPort)
 }
 
-func buildHTTPRouteFilters(annotations map[string]string) []gatewayv1.HTTPRouteFilter {
-	var filters []gatewayv1.HTTPRouteFilter
-
-	if enableCors, exists := annotations["nginx.ingress.kubernetes.io/enable-cors"]; exists && enableCors == "true" {
-		logger.Warn("CORS annotation detected. Note: CORS configuration in HTTPRoute may differ between Gateway API implementations. " +
-			"See GatewayAPIMigration.md section 8 for manual configuration")
-	}
-
-	if snippet, exists := annotations["nginx.ingress.kubernetes.io/configuration-snippet"]; exists && snippet != "" {
-		logger.Warn("Ingress annotation 'configuration-snippet' found but cannot be automatically converted to HTTPRoute. " +
-			"Manual conversion required using RequestHeaderModifier/ResponseHeaderModifier filters. See GatewayAPIMigration.md section 6")
-	}
-
-	return filters
-}
-
 func buildHTTPRouteRule(route Route, annotations map[string]string) gatewayv1.HTTPRouteRule {
 	pathType := pathMatchTypeFromRoute(route.Spec.PathType)
 	path := routePathValue(route.Spec.Path)
 	port := routeBackendPort(route.Spec.Port.TargetPort)
-	filters := buildHTTPRouteFilters(annotations)
 
 	rule := gatewayv1.HTTPRouteRule{
 		Matches: []gatewayv1.HTTPRouteMatch{
@@ -341,11 +331,7 @@ func buildHTTPRouteRule(route Route, annotations map[string]string) gatewayv1.HT
 		},
 	}
 
-	if len(filters) > 0 {
-		rule.Filters = filters
-	}
-
-	if affinity, exists := annotations["nginx.ingress.kubernetes.io/affinity"]; exists && affinity == "cookie" {
+	if affinity, exists := annotations[AnnotationAffinity]; exists && affinity == "cookie" {
 		if sessionPersistence := buildSessionPersistence(annotations); sessionPersistence != nil {
 			rule.SessionPersistence = sessionPersistence
 		}
@@ -396,48 +382,12 @@ func buildTimeouts(annotations map[string]string) *gatewayv1.HTTPRouteTimeouts {
 
 	timeouts := &gatewayv1.HTTPRouteTimeouts{}
 
-	if readTimeout, exists := annotations["nginx.ingress.kubernetes.io/proxy-read-timeout"]; exists && readTimeout != "" {
+	if readTimeout, exists := annotations[AnnotationProxyReadTimeout]; exists && readTimeout != "" {
 		timeout := gatewayv1.Duration(readTimeout + "s")
 		timeouts.Request = &timeout
 	}
 
 	return timeouts
-}
-
-func logAdditionalResourceWarnings(annotations map[string]string, routeName string) {
-	if protocol, exists := annotations["nginx.ingress.kubernetes.io/backend-protocol"]; exists && protocol == "HTTPS" {
-		logger.Warn("Route '%s': Ingress annotation 'backend-protocol: HTTPS' requires BackendTLSPolicy resource. "+
-			"See GatewayAPIMigration.md section 5", routeName)
-	}
-	if annotations["nginx.ingress.kubernetes.io/secure-backends"] != "" {
-		logger.Warn("Route '%s': Ingress annotation 'secure-backends' requires BackendTLSPolicy resource. "+
-			"See GatewayAPIMigration.md section 5", routeName)
-	}
-
-	if protocol, exists := annotations["nginx.ingress.kubernetes.io/backend-protocol"]; exists && protocol == "GRPC" {
-		logger.Warn("Route '%s': Ingress annotation 'backend-protocol: GRPC' requires BackendTrafficPolicy resource with useClientProtocol. "+
-			"See GatewayAPIMigration.md section 8", routeName)
-	}
-
-	if annotations["nginx.ingress.kubernetes.io/proxy-connect-timeout"] != "" {
-		logger.Warn("Route '%s': Ingress annotation 'proxy-connect-timeout' requires BackendTrafficPolicy resource. "+
-			"See GatewayAPIMigration.md section 9", routeName)
-	}
-
-	if annotations["nginx.ingress.kubernetes.io/auth-type"] != "" {
-		logger.Warn("Route '%s': Ingress annotation 'auth-type' requires SecurityPolicy resource. "+
-			"See GatewayAPIMigration.md section 13", routeName)
-	}
-
-	if passthrough, exists := annotations["nginx.ingress.kubernetes.io/ssl-passthrough"]; exists && passthrough == "true" {
-		logger.Warn("Route '%s': Ingress annotation 'ssl-passthrough' requires TLSRoute resource instead of HTTPRoute. "+
-			"See GatewayAPIMigration.md section 12", routeName)
-	}
-
-	if annotations["nginx.ingress.kubernetes.io/app-root"] != "" {
-		logger.Warn("Route '%s': Ingress annotation 'app-root' requires additional HTTPRoute rule with RequestRedirect filter. "+
-			"See GatewayAPIMigration.md section 7", routeName)
-	}
 }
 
 func RouteFromHTTPRouteGatewayV1(httpRoute *gatewayv1.HTTPRoute) *Route {

--- a/entity/route.go
+++ b/entity/route.go
@@ -241,13 +241,10 @@ func (route Route) GetMetadata() Metadata {
 }
 
 func (route Route) ToHTTPRoute(gatewayNamespace, gatewayName string) *gatewayv1.HTTPRoute {
+	annotations := normalizeRouteAnnotations(route.Metadata.Annotations)
+
 	httpRoute := &gatewayv1.HTTPRoute{
 		ObjectMeta: *route.Metadata.ToObjectMeta(),
-	}
-
-	annotations := route.Metadata.Annotations
-	if annotations == nil {
-		annotations = make(map[string]string)
 	}
 
 	ns := gatewayv1.Namespace(gatewayNamespace)
@@ -259,34 +256,53 @@ func (route Route) ToHTTPRoute(gatewayNamespace, gatewayName string) *gatewayv1.
 	}
 
 	httpRoute.Spec.Hostnames = []gatewayv1.Hostname{gatewayv1.Hostname(route.Spec.Host)}
+	httpRoute.Spec.Rules = []gatewayv1.HTTPRouteRule{buildHTTPRouteRule(route, annotations)}
 
-	pathType := gatewayv1.PathMatchPathPrefix
-	if route.Spec.PathType != "" {
-		switch route.Spec.PathType {
-		case "Exact":
-			pathType = gatewayv1.PathMatchExact
-		case "Prefix", "ImplementationSpecific":
-			pathType = gatewayv1.PathMatchPathPrefix
-		default:
-			pathType = gatewayv1.PathMatchPathPrefix
-		}
+	logAdditionalResourceWarnings(annotations, route.Metadata.Name)
+
+	return httpRoute
+}
+
+func normalizeRouteAnnotations(annotations map[string]string) map[string]string {
+	if annotations == nil {
+		return make(map[string]string)
 	}
+	return annotations
+}
 
-	path := route.Spec.Path
+func pathMatchTypeFromRoute(pathType string) gatewayv1.PathMatchType {
+	if pathType == "" {
+		return gatewayv1.PathMatchPathPrefix
+	}
+	switch pathType {
+	case "Exact":
+		return gatewayv1.PathMatchExact
+	case "Prefix", "ImplementationSpecific":
+		return gatewayv1.PathMatchPathPrefix
+	default:
+		return gatewayv1.PathMatchPathPrefix
+	}
+}
+
+func routePathValue(path string) string {
 	if path == "" {
-		path = "/"
+		return "/"
 	}
+	return path
+}
 
-	port := gatewayv1.PortNumber(route.Spec.Port.TargetPort)
-	if port == 0 {
-		port = 8080
+func routeBackendPort(targetPort int32) gatewayv1.PortNumber {
+	if targetPort == 0 {
+		return 8080
 	}
+	return gatewayv1.PortNumber(targetPort)
+}
 
+func buildHTTPRouteFilters(annotations map[string]string) []gatewayv1.HTTPRouteFilter {
 	var filters []gatewayv1.HTTPRouteFilter
 
 	if enableCors, exists := annotations["nginx.ingress.kubernetes.io/enable-cors"]; exists && enableCors == "true" {
-		corsFilter := buildCORSFilter(annotations)
-		if corsFilter != nil {
+		if corsFilter := buildCORSFilter(annotations); corsFilter != nil {
 			filters = append(filters, *corsFilter)
 		}
 	}
@@ -295,6 +311,15 @@ func (route Route) ToHTTPRoute(gatewayNamespace, gatewayName string) *gatewayv1.
 		logger.Warn("Ingress annotation 'configuration-snippet' found but cannot be automatically converted to HTTPRoute. " +
 			"Manual conversion required using RequestHeaderModifier/ResponseHeaderModifier filters. See GatewayAPIMigration.md section 6")
 	}
+
+	return filters
+}
+
+func buildHTTPRouteRule(route Route, annotations map[string]string) gatewayv1.HTTPRouteRule {
+	pathType := pathMatchTypeFromRoute(route.Spec.PathType)
+	path := routePathValue(route.Spec.Path)
+	port := routeBackendPort(route.Spec.Port.TargetPort)
+	filters := buildHTTPRouteFilters(annotations)
 
 	rule := gatewayv1.HTTPRouteRule{
 		Matches: []gatewayv1.HTTPRouteMatch{
@@ -322,8 +347,7 @@ func (route Route) ToHTTPRoute(gatewayNamespace, gatewayName string) *gatewayv1.
 	}
 
 	if affinity, exists := annotations["nginx.ingress.kubernetes.io/affinity"]; exists && affinity == "cookie" {
-		sessionPersistence := buildSessionPersistence(annotations)
-		if sessionPersistence != nil {
+		if sessionPersistence := buildSessionPersistence(annotations); sessionPersistence != nil {
 			rule.SessionPersistence = sessionPersistence
 		}
 	}
@@ -332,11 +356,7 @@ func (route Route) ToHTTPRoute(gatewayNamespace, gatewayName string) *gatewayv1.
 		rule.Timeouts = timeouts
 	}
 
-	httpRoute.Spec.Rules = []gatewayv1.HTTPRouteRule{rule}
-
-	logAdditionalResourceWarnings(annotations, route.Metadata.Name)
-
-	return httpRoute
+	return rule
 }
 
 func buildCORSFilter(annotations map[string]string) *gatewayv1.HTTPRouteFilter {

--- a/entity/route.go
+++ b/entity/route.go
@@ -302,9 +302,8 @@ func buildHTTPRouteFilters(annotations map[string]string) []gatewayv1.HTTPRouteF
 	var filters []gatewayv1.HTTPRouteFilter
 
 	if enableCors, exists := annotations["nginx.ingress.kubernetes.io/enable-cors"]; exists && enableCors == "true" {
-		if corsFilter := buildCORSFilter(annotations); corsFilter != nil {
-			filters = append(filters, *corsFilter)
-		}
+		logger.Warn("CORS annotation detected. Note: CORS configuration in HTTPRoute may differ between Gateway API implementations. " +
+			"See GatewayAPIMigration.md section 8 for manual configuration")
 	}
 
 	if snippet, exists := annotations["nginx.ingress.kubernetes.io/configuration-snippet"]; exists && snippet != "" {
@@ -357,14 +356,6 @@ func buildHTTPRouteRule(route Route, annotations map[string]string) gatewayv1.HT
 	}
 
 	return rule
-}
-
-func buildCORSFilter(annotations map[string]string) *gatewayv1.HTTPRouteFilter {
-
-	logger.Warn("CORS annotation detected. Note: CORS configuration in HTTPRoute may differ between Gateway API implementations. " +
-		"See GatewayAPIMigration.md section 8 for manual configuration")
-
-	return nil
 }
 
 func buildSessionPersistence(annotations map[string]string) *gatewayv1.SessionPersistence {

--- a/entity/route.go
+++ b/entity/route.go
@@ -364,11 +364,11 @@ func buildSessionPersistence(annotations map[string]string) *gatewayv1.SessionPe
 		Type: &persistenceType,
 	}
 
-	if cookieName, exists := annotations["nginx.ingress.kubernetes.io/session-cookie-name"]; exists && cookieName != "" {
+	if cookieName := annotations["nginx.ingress.kubernetes.io/session-cookie-name"]; cookieName != "" {
 		sessionPersistence.SessionName = &cookieName
 	}
 
-	if maxAge, exists := annotations["nginx.ingress.kubernetes.io/session-cookie-max-age"]; exists && maxAge != "" {
+	if maxAge := annotations["nginx.ingress.kubernetes.io/session-cookie-max-age"]; maxAge != "" {
 		timeout := gatewayv1.Duration(maxAge + "s")
 		sessionPersistence.AbsoluteTimeout = &timeout
 	}
@@ -409,7 +409,7 @@ func logAdditionalResourceWarnings(annotations map[string]string, routeName stri
 		logger.Warn("Route '%s': Ingress annotation 'backend-protocol: HTTPS' requires BackendTLSPolicy resource. "+
 			"See GatewayAPIMigration.md section 5", routeName)
 	}
-	if _, exists := annotations["nginx.ingress.kubernetes.io/secure-backends"]; exists {
+	if annotations["nginx.ingress.kubernetes.io/secure-backends"] != "" {
 		logger.Warn("Route '%s': Ingress annotation 'secure-backends' requires BackendTLSPolicy resource. "+
 			"See GatewayAPIMigration.md section 5", routeName)
 	}
@@ -419,12 +419,12 @@ func logAdditionalResourceWarnings(annotations map[string]string, routeName stri
 			"See GatewayAPIMigration.md section 8", routeName)
 	}
 
-	if _, exists := annotations["nginx.ingress.kubernetes.io/proxy-connect-timeout"]; exists {
+	if annotations["nginx.ingress.kubernetes.io/proxy-connect-timeout"] != "" {
 		logger.Warn("Route '%s': Ingress annotation 'proxy-connect-timeout' requires BackendTrafficPolicy resource. "+
 			"See GatewayAPIMigration.md section 9", routeName)
 	}
 
-	if _, exists := annotations["nginx.ingress.kubernetes.io/auth-type"]; exists {
+	if annotations["nginx.ingress.kubernetes.io/auth-type"] != "" {
 		logger.Warn("Route '%s': Ingress annotation 'auth-type' requires SecurityPolicy resource. "+
 			"See GatewayAPIMigration.md section 13", routeName)
 	}
@@ -434,7 +434,7 @@ func logAdditionalResourceWarnings(annotations map[string]string, routeName stri
 			"See GatewayAPIMigration.md section 12", routeName)
 	}
 
-	if _, exists := annotations["nginx.ingress.kubernetes.io/app-root"]; exists {
+	if annotations["nginx.ingress.kubernetes.io/app-root"] != "" {
 		logger.Warn("Route '%s': Ingress annotation 'app-root' requires additional HTTPRoute rule with RequestRedirect filter. "+
 			"See GatewayAPIMigration.md section 7", routeName)
 	}
@@ -442,7 +442,6 @@ func logAdditionalResourceWarnings(annotations map[string]string, routeName stri
 
 func RouteFromHTTPRouteGatewayV1(httpRoute *gatewayv1.HTTPRoute) *Route {
 	logger.Debugf("Processing RouteFromHTTPRouteGatewayV1, httpRoute: %s", httpRoute.Name)
-	metadata := *FromObjectMeta("Route", &httpRoute.ObjectMeta)
 
 	var routeSpec RouteSpec
 	if len(httpRoute.Spec.Rules) > 0 &&
@@ -484,5 +483,6 @@ func RouteFromHTTPRouteGatewayV1(httpRoute *gatewayv1.HTTPRoute) *Route {
 		}
 	}
 
+	metadata := *FromObjectMeta("Route", &httpRoute.ObjectMeta)
 	return &Route{Spec: routeSpec, Metadata: metadata}
 }

--- a/entity/route_test.go
+++ b/entity/route_test.go
@@ -534,7 +534,7 @@ func TestRouteBackendPort(t *testing.T) {
 	assert.Equal(t, int32(9090), int32(routeBackendPort(9090)))
 }
 
-func TestRouteFromHTTPRouteGatewayV1(t *testing.T) {
+func TestRouteFromHTTPRoute(t *testing.T) {
 	pathType := "PathPrefix"
 	pathValue := "/test-path"
 	port := int32(8080)
@@ -572,7 +572,7 @@ func TestRouteFromHTTPRouteGatewayV1(t *testing.T) {
 		},
 	}
 
-	route := RouteFromHTTPRouteGatewayV1(httpRoute)
+	route := RouteFromHTTPRoute(httpRoute)
 
 	assert.Equal(t, testName, route.Metadata.Name)
 	assert.Equal(t, testNamespace, route.Metadata.Namespace)
@@ -583,7 +583,7 @@ func TestRouteFromHTTPRouteGatewayV1(t *testing.T) {
 	assert.Equal(t, port, route.Spec.Port.TargetPort)
 }
 
-func TestRouteFromHTTPRouteGatewayV1_EmptyRules(t *testing.T) {
+func TestRouteFromHTTPRoute_EmptyRules(t *testing.T) {
 	httpRoute := &gatewayv1.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      testName,
@@ -592,7 +592,7 @@ func TestRouteFromHTTPRouteGatewayV1_EmptyRules(t *testing.T) {
 		Spec: gatewayv1.HTTPRouteSpec{},
 	}
 
-	route := RouteFromHTTPRouteGatewayV1(httpRoute)
+	route := RouteFromHTTPRoute(httpRoute)
 
 	assert.Equal(t, testName, route.Metadata.Name)
 	assert.Equal(t, "", route.Spec.Host)

--- a/entity/route_test.go
+++ b/entity/route_test.go
@@ -617,30 +617,31 @@ func TestBuildSessionPersistence(t *testing.T) {
 
 func TestBuildTimeouts(t *testing.T) {
 	tests := []struct {
-		name        string
-		annotations map[string]string
-		expectNil   bool
+		name            string
+		annotations     map[string]string
+		expectNil       bool
+		expectedRequest string
 	}{
 		{
 			name: "With proxy-read-timeout",
 			annotations: map[string]string{
 				AnnotationProxyReadTimeout: "1800",
 			},
-			expectNil: false,
+			expectedRequest: "1800s",
 		},
 		{
 			name: "With proxy-send-timeout",
 			annotations: map[string]string{
 				AnnotationProxySendTimeout: "900",
 			},
-			expectNil: false,
+			expectedRequest: "900s",
 		},
 		{
-			name: "With proxy-connect-timeout",
+			name: "With proxy-connect-timeout only",
 			annotations: map[string]string{
 				AnnotationProxyConnectTimeout: "600",
 			},
-			expectNil: false,
+			expectNil: true,
 		},
 		{
 			name:        "Without timeout annotations",
@@ -654,9 +655,11 @@ func TestBuildTimeouts(t *testing.T) {
 			timeouts := buildTimeouts(tt.annotations)
 			if tt.expectNil {
 				assert.Nil(t, timeouts)
-			} else {
-				assert.NotNil(t, timeouts)
+				return
 			}
+			assert.NotNil(t, timeouts)
+			assert.NotNil(t, timeouts.Request)
+			assert.Equal(t, tt.expectedRequest, string(*timeouts.Request))
 		})
 	}
 }

--- a/entity/route_test.go
+++ b/entity/route_test.go
@@ -9,6 +9,7 @@ import (
 	networkingV1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 const (
@@ -437,4 +438,256 @@ func TestNewRouteFromInterface(t *testing.T) {
 	route := createSimpleRoute("", 0)
 	route.Spec.IngressClassName = nil // OpenShift does not support IngressClassName
 	assert.Equal(t, route, NewRouteFromInterface(createRouteMap()))
+}
+
+func TestToHTTPRoute(t *testing.T) {
+	route := createSimpleRoute("Prefix", int32(testPort))
+	httpRoute := route.ToHTTPRoute("gateway-system", "default-external-gateway")
+
+	assert.Equal(t, testName, httpRoute.Name)
+	assert.Equal(t, testNamespace, httpRoute.Namespace)
+	assert.Equal(t, 1, len(httpRoute.Spec.ParentRefs))
+	assert.Equal(t, "default-external-gateway", string(httpRoute.Spec.ParentRefs[0].Name))
+	assert.Equal(t, "gateway-system", string(*httpRoute.Spec.ParentRefs[0].Namespace))
+	assert.Equal(t, 1, len(httpRoute.Spec.Hostnames))
+	assert.Equal(t, testHost, string(httpRoute.Spec.Hostnames[0]))
+	assert.Equal(t, 1, len(httpRoute.Spec.Rules))
+	assert.Equal(t, testPath, *httpRoute.Spec.Rules[0].Matches[0].Path.Value)
+	assert.Equal(t, testServiceName, string(httpRoute.Spec.Rules[0].BackendRefs[0].Name))
+	assert.Equal(t, int32(testPort), int32(*httpRoute.Spec.Rules[0].BackendRefs[0].Port))
+}
+
+func TestToHTTPRoute_WithDefaults(t *testing.T) {
+	route := &Route{
+		Metadata: Metadata{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+		Spec: RouteSpec{
+			Host:    testHost,
+			Service: Target{Name: testServiceName},
+		},
+	}
+
+	httpRoute := route.ToHTTPRoute("gateway-system", "default-external-gateway")
+
+	assert.Equal(t, "/", *httpRoute.Spec.Rules[0].Matches[0].Path.Value)
+	assert.Equal(t, int32(8080), int32(*httpRoute.Spec.Rules[0].BackendRefs[0].Port))
+	assert.Equal(t, "PathPrefix", string(*httpRoute.Spec.Rules[0].Matches[0].Path.Type))
+}
+
+func TestToHTTPRoute_WithSessionAffinity(t *testing.T) {
+	route := createSimpleRoute("Prefix", int32(testPort))
+	route.Metadata.Annotations = map[string]string{
+		AnnotationAffinity:            "cookie",
+		AnnotationSessionCookieName:   "my-cookie",
+		AnnotationSessionCookieMaxAge: "3600",
+	}
+
+	httpRoute := route.ToHTTPRoute("gateway-system", "default-external-gateway")
+
+	assert.NotNil(t, httpRoute.Spec.Rules[0].SessionPersistence)
+	assert.Equal(t, "my-cookie", *httpRoute.Spec.Rules[0].SessionPersistence.SessionName)
+	assert.Equal(t, "3600s", string(*httpRoute.Spec.Rules[0].SessionPersistence.AbsoluteTimeout))
+}
+
+func TestToHTTPRoute_WithTimeouts(t *testing.T) {
+	route := createSimpleRoute("Prefix", int32(testPort))
+	route.Metadata.Annotations = map[string]string{
+		AnnotationProxyReadTimeout: "1800",
+	}
+
+	httpRoute := route.ToHTTPRoute("gateway-system", "default-external-gateway")
+
+	assert.NotNil(t, httpRoute.Spec.Rules[0].Timeouts)
+	assert.Equal(t, "1800s", string(*httpRoute.Spec.Rules[0].Timeouts.Request))
+}
+
+func TestPathMatchTypeFromRoute(t *testing.T) {
+	tests := []struct {
+		name     string
+		pathType string
+		expected string
+	}{
+		{"Empty defaults to PathPrefix", "", "PathPrefix"},
+		{"Exact maps to Exact", "Exact", "Exact"},
+		{"Prefix maps to PathPrefix", "Prefix", "PathPrefix"},
+		{"ImplementationSpecific maps to PathPrefix", "ImplementationSpecific", "PathPrefix"},
+		{"Unknown defaults to PathPrefix", "Unknown", "PathPrefix"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := pathMatchTypeFromRoute(tt.pathType)
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
+}
+
+func TestRoutePathValue(t *testing.T) {
+	assert.Equal(t, "/", routePathValue(""))
+	assert.Equal(t, "/api", routePathValue("/api"))
+}
+
+func TestRouteBackendPort(t *testing.T) {
+	assert.Equal(t, int32(8080), int32(routeBackendPort(0)))
+	assert.Equal(t, int32(9090), int32(routeBackendPort(9090)))
+}
+
+func TestRouteFromHTTPRouteGatewayV1(t *testing.T) {
+	pathType := "PathPrefix"
+	pathValue := "/test-path"
+	port := int32(8080)
+	hostname := "example.com"
+
+	httpRoute := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Hostnames: []gatewayv1.Hostname{gatewayv1.Hostname(hostname)},
+			Rules: []gatewayv1.HTTPRouteRule{
+				{
+					Matches: []gatewayv1.HTTPRouteMatch{
+						{
+							Path: &gatewayv1.HTTPPathMatch{
+								Type:  (*gatewayv1.PathMatchType)(&pathType),
+								Value: &pathValue,
+							},
+						},
+					},
+					BackendRefs: []gatewayv1.HTTPBackendRef{
+						{
+							BackendRef: gatewayv1.BackendRef{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: gatewayv1.ObjectName(testServiceName),
+									Port: (*gatewayv1.PortNumber)(&port),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	route := RouteFromHTTPRouteGatewayV1(httpRoute)
+
+	assert.Equal(t, testName, route.Metadata.Name)
+	assert.Equal(t, testNamespace, route.Metadata.Namespace)
+	assert.Equal(t, hostname, route.Spec.Host)
+	assert.Equal(t, pathValue, route.Spec.Path)
+	assert.Equal(t, pathType, route.Spec.PathType)
+	assert.Equal(t, testServiceName, route.Spec.Service.Name)
+	assert.Equal(t, port, route.Spec.Port.TargetPort)
+}
+
+func TestRouteFromHTTPRouteGatewayV1_EmptyRules(t *testing.T) {
+	httpRoute := &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      testName,
+			Namespace: testNamespace,
+		},
+		Spec: gatewayv1.HTTPRouteSpec{},
+	}
+
+	route := RouteFromHTTPRouteGatewayV1(httpRoute)
+
+	assert.Equal(t, testName, route.Metadata.Name)
+	assert.Equal(t, "", route.Spec.Host)
+	assert.Equal(t, "", route.Spec.Path)
+	assert.Equal(t, "", route.Spec.Service.Name)
+	assert.Equal(t, int32(0), route.Spec.Port.TargetPort)
+}
+
+func TestBuildSessionPersistence(t *testing.T) {
+	annotations := map[string]string{
+		AnnotationAffinity:            "cookie",
+		AnnotationSessionCookieName:   "test-cookie",
+		AnnotationSessionCookieMaxAge: "7200",
+	}
+
+	sessionPersistence := buildSessionPersistence(annotations)
+
+	assert.NotNil(t, sessionPersistence)
+	assert.Equal(t, "test-cookie", *sessionPersistence.SessionName)
+	assert.Equal(t, "7200s", string(*sessionPersistence.AbsoluteTimeout))
+}
+
+func TestBuildTimeouts(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expectNil   bool
+	}{
+		{
+			name: "With proxy-read-timeout",
+			annotations: map[string]string{
+				AnnotationProxyReadTimeout: "1800",
+			},
+			expectNil: false,
+		},
+		{
+			name: "With proxy-send-timeout",
+			annotations: map[string]string{
+				AnnotationProxySendTimeout: "900",
+			},
+			expectNil: false,
+		},
+		{
+			name: "With proxy-connect-timeout",
+			annotations: map[string]string{
+				AnnotationProxyConnectTimeout: "600",
+			},
+			expectNil: false,
+		},
+		{
+			name:        "Without timeout annotations",
+			annotations: map[string]string{},
+			expectNil:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			timeouts := buildTimeouts(tt.annotations)
+			if tt.expectNil {
+				assert.Nil(t, timeouts)
+			} else {
+				assert.NotNil(t, timeouts)
+			}
+		})
+	}
+}
+
+func TestNormalizeRouteAnnotations(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expectEmpty bool
+	}{
+		{
+			name:        "Nil annotations",
+			annotations: nil,
+			expectEmpty: true,
+		},
+		{
+			name:        "Non-nil annotations",
+			annotations: map[string]string{"key": "value"},
+			expectEmpty: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeRouteAnnotations(tt.annotations)
+			assert.NotNil(t, result)
+			if tt.expectEmpty {
+				assert.Empty(t, result)
+			} else {
+				assert.Equal(t, tt.annotations, result)
+			}
+		})
+	}
 }

--- a/service/builder.go
+++ b/service/builder.go
@@ -29,6 +29,9 @@ type PlatformClientBuilder struct {
 	consulEnabled           *bool
 	consulUrl               *string
 	consulToken             *string
+	gatewaySystemType       *string
+	gatewaySystemNamespace  *string
+	gatewaySystemName       *string
 }
 
 func NewPlatformClientBuilder() PlatformClientBuilder {
@@ -152,6 +155,21 @@ func (builder PlatformClientBuilder) WithConsul(consulEnabled bool, consulUrl st
 		s := ""
 		builder.consulToken = &s
 	}
+	return builder
+}
+
+func (builder PlatformClientBuilder) WithGatewaySystemType(gatewaySystemType string) PlatformClientBuilder {
+	builder.gatewaySystemType = &gatewaySystemType
+	return builder
+}
+
+func (builder PlatformClientBuilder) WithGatewaySystemNamespace(namespace string) PlatformClientBuilder {
+	builder.gatewaySystemNamespace = &namespace
+	return builder
+}
+
+func (builder PlatformClientBuilder) WithGatewaySystemName(name string) PlatformClientBuilder {
+	builder.gatewaySystemName = &name
 	return builder
 }
 

--- a/service/builder_test.go
+++ b/service/builder_test.go
@@ -380,6 +380,25 @@ func TestPlatformClientBuilder_WithBasicCaches_Openshift311(t *testing.T) {
 	testBasicCaches(t, realClient.Kubernetes.Cache)
 }
 
+func TestPlatformClientBuilder_WithGatewaySystemConfig_k8s(t *testing.T) {
+	r := require.New(t)
+	prepareEnv("kubernetes")
+	defer cleanUpEnv()
+
+	client, err := NewPlatformClientBuilder().
+		WithClients(prepareFakeClients()).
+		WithWatchExecutor(getTestWatchExecutor(t)).
+		WithGatewaySystemType(kubernetes.GatewayApiDefault).
+		WithGatewaySystemNamespace("custom-ns").
+		WithGatewaySystemName("custom-gateway").
+		Build()
+	r.NoError(err)
+	kube := getK8sEntityFromClient(client)
+	r.Equal(kubernetes.GatewayApiDefault, kube.GatewaySystem.Type)
+	r.Equal("custom-ns", kube.GatewaySystem.Namespace)
+	r.Equal("custom-gateway", kube.GatewaySystem.Name)
+}
+
 func TestPlatformClientBuilder_WithGatewayApiRoutesCaches_k8s(t *testing.T) {
 	r := require.New(t)
 	prepareEnv("kubernetes")

--- a/service/internal/cache/cache.go
+++ b/service/internal/cache/cache.go
@@ -120,7 +120,10 @@ func newEntityAdapter[T entity.HasMetadata](sharedAdapter *ristrettoCacheAdapter
 func (cache *ResourceCache[T]) Set(ctx context.Context, resource T) (bool, error) {
 	metadata := resource.GetMetadata()
 	ok := cache.Cache.Set(cache.Kind, metadata.Namespace, metadata.Name, resource)
-	return ok, nil
+	if !ok {
+		return false, fmt.Errorf("failed to place %s/%s/%s into cache", cache.Kind, metadata.Namespace, metadata.Name)
+	}
+	return true, nil
 }
 
 func (cache *ResourceCache[T]) Delete(ctx context.Context, namespace string, name string) {

--- a/service/internal/cache/cache_test.go
+++ b/service/internal/cache/cache_test.go
@@ -63,8 +63,9 @@ func TestCacheItemIgnoredDueToMaxItemSize(t *testing.T) {
 	assertions.NoError(err)
 
 	ok, err := cache.ConfigMaps.Set(ctx, configMap1)
-	assertions.NoError(err)
+	assertions.Error(err)
 	assertions.False(ok)
+	assertions.Contains(err.Error(), "failed to place")
 
 	configMapFromCache1 := cache.ConfigMaps.Get(ctx, configMap1.Namespace, configMap1.Name)
 	assertions.Nil(configMapFromCache1)

--- a/service/internal/kubernetes/adapterForCache.go
+++ b/service/internal/kubernetes/adapterForCache.go
@@ -13,6 +13,7 @@ import (
 	"github.com/netcracker/qubership-core-lib-go/v3/logging"
 	coreV1 "k8s.io/api/core/v1"
 	networkingV1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -68,13 +69,13 @@ func NewCacheAdapters(ctx context.Context, namespace string, cache *cache.Resour
 	}
 
 	if cache.HTTPRoute != nil && watchHandlers.HTTPRouteV1 != nil {
-		if adapters.HTTPRouteV1, err = newCacheAdapter(ctx, namespace, cache.HTTPRoute, watchHandlers.HTTPRouteV1); err != nil {
+		if adapters.HTTPRouteV1, err = startGatewayRouteCacheAdapter(ctx, namespace, cache.HTTPRoute, watchHandlers.HTTPRouteV1, "httproutes"); err != nil {
 			return nil, err
 		}
 	}
 
 	if cache.GRPCRoute != nil && watchHandlers.GRPCRouteV1 != nil {
-		if adapters.GRPCRouteV1, err = newCacheAdapter(ctx, namespace, cache.GRPCRoute, watchHandlers.GRPCRouteV1); err != nil {
+		if adapters.GRPCRouteV1, err = startGatewayRouteCacheAdapter(ctx, namespace, cache.GRPCRoute, watchHandlers.GRPCRouteV1, "grpcroutes"); err != nil {
 			return nil, err
 		}
 	}
@@ -87,6 +88,20 @@ type CacheAdapter[F runtime.Object, T entity.HasMetadata] struct {
 	Cache          *cache.ResourceCache[T]
 	WatcherHandler *SharedWatchHandler[F, T]
 	logger         logging.Logger
+}
+
+func startGatewayRouteCacheAdapter[F runtime.Object, T entity.HasMetadata](ctx context.Context, namespace string,
+	resourceCache *cache.ResourceCache[T], watchHandler *SharedWatchHandler[F, T], resourceName string) (*CacheAdapter[F, T], error) {
+	adapter, err := newCacheAdapter(ctx, namespace, resourceCache, watchHandler)
+	if err == nil {
+		return adapter, nil
+	}
+	if apierrors.IsForbidden(err) {
+		loggerCacheAdapter.WarnC(ctx, "Gateway %s cache watch is disabled: %v. Grant watch access to %s in gateway.networking.k8s.io for namespace %s",
+			resourceName, err, resourceName, namespace)
+		return nil, nil
+	}
+	return nil, err
 }
 
 func newCacheAdapter[F runtime.Object, T entity.HasMetadata](ctx context.Context, namespace string,

--- a/service/internal/kubernetes/adapterForCache_test.go
+++ b/service/internal/kubernetes/adapterForCache_test.go
@@ -99,7 +99,7 @@ func TestCacheAdapters(t *testing.T) {
 			resourceDeleted := createHttpRoute(testResourceName, 2, "3")
 			resourceCache := resourcesCache.HTTPRoute
 			assertions.NotNil(resourceCache)
-			testCacheAdapter(ctx, t, testResourceName, resourceAdded, resourceModified, resourceDeleted, entity.RouteFromHTTPRoute, resourceCache, watchExecutor1)
+			testCacheAdapter(ctx, t, testResourceName, resourceAdded, resourceModified, resourceDeleted, entity.WrapHTTPRoute, resourceCache, watchExecutor1)
 		case cache.GrpcRouteCache:
 			resourceAdded := createGrpcRoute(testResourceName, 1, "1")
 			resourceModified := createGrpcRoute(testResourceName, 2, "2")

--- a/service/internal/kubernetes/adapterForCache_test.go
+++ b/service/internal/kubernetes/adapterForCache_test.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"context"
-	"errors"
 	"reflect"
 	"sync"
 	"testing"
@@ -13,14 +12,11 @@ import (
 	"github.com/netcracker/qubership-core-lib-go-paas-mediation-client/v8/service/internal/cache"
 	"github.com/netcracker/qubership-core-lib-go/v3/logging"
 	"github.com/stretchr/testify/require"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	fakeWatch "k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
+	"k8s.io/client-go/kubernetes"
+	gatewayv1 "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/typed/apis/v1"
 )
 
 func TestCacheAdapters(t *testing.T) {
@@ -31,6 +27,8 @@ func TestCacheAdapters(t *testing.T) {
 		cache.ServiceCache,
 		cache.SecretCache,
 		cache.RouteCache,
+		cache.HttpRouteCache,
+		cache.GrpcRouteCache,
 		//cache.CertificateCache, //todo not supported yet
 	} {
 
@@ -42,16 +40,16 @@ func TestCacheAdapters(t *testing.T) {
 			0: func() (fakeWatch.Interface, error) { return watchExecutor1, nil },
 		}}
 
-		clientset := fake.NewClientset()
+		clientset := &kubernetes.Clientset{}
 		cert_client := &certClient.Clientset{}
-		gatewayREST := clientset.CoreV1().RESTClient()
+		gatewayClient := &gatewayv1.GatewayV1Client{}
 		watchHandlers := NewSharedWatchEventHandlers(watchExecutor, watchTimeout,
 			clientset.CoreV1().RESTClient(),
 			cert_client.CertmanagerV1().RESTClient(),
 			clientset.NetworkingV1().RESTClient(),
 			clientset.ExtensionsV1beta1().RESTClient())
-		watchHandlers.WithHTTPRouteV1(watchExecutor, watchTimeout, gatewayREST)
-		watchHandlers.WithGRPCRouteV1(watchExecutor, watchTimeout, gatewayREST)
+		watchHandlers.WithHTTPRouteV1(watchExecutor, watchTimeout, gatewayClient.RESTClient())
+		watchHandlers.WithGRPCRouteV1(watchExecutor, watchTimeout, gatewayClient.RESTClient())
 		resourcesCache := cache.NewTestResourcesCache(cacheType)
 		cacheAdapters, err := NewCacheAdapters(ctx, testNamespace1, resourcesCache, watchHandlers)
 		assertions.NoError(err)
@@ -95,22 +93,22 @@ func TestCacheAdapters(t *testing.T) {
 			resourceCache := resourcesCache.Certificates
 			assertions.NotNil(resourceCache)
 			testCacheAdapter(ctx, t, testResourceName, resourceAdded, resourceModified, resourceDeleted, entity.NewCertificate, resourceCache, watchExecutor1)
+		case cache.HttpRouteCache:
+			resourceAdded := createHttpRoute(testResourceName, 1, "1")
+			resourceModified := createHttpRoute(testResourceName, 2, "2")
+			resourceDeleted := createHttpRoute(testResourceName, 2, "3")
+			resourceCache := resourcesCache.HTTPRoute
+			assertions.NotNil(resourceCache)
+			testCacheAdapter(ctx, t, testResourceName, resourceAdded, resourceModified, resourceDeleted, entity.RouteFromHTTPRoute, resourceCache, watchExecutor1)
+		case cache.GrpcRouteCache:
+			resourceAdded := createGrpcRoute(testResourceName, 1, "1")
+			resourceModified := createGrpcRoute(testResourceName, 2, "2")
+			resourceDeleted := createGrpcRoute(testResourceName, 2, "3")
+			resourceCache := resourcesCache.GRPCRoute
+			assertions.NotNil(resourceCache)
+			testCacheAdapter(ctx, t, testResourceName, resourceAdded, resourceModified, resourceDeleted, entity.RouteFromGRPCRoute, resourceCache, watchExecutor1)
 		}
 	}
-}
-
-func testGatewayRESTClient(t *testing.T) rest.Interface {
-	t.Helper()
-	cfg := &rest.Config{
-		Host: "https://127.0.0.1:6443",
-		ContentConfig: rest.ContentConfig{
-			GroupVersion:         &schema.GroupVersion{Group: "gateway.networking.k8s.io", Version: "v1"},
-			NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
-		},
-	}
-	restClient, err := rest.RESTClientFor(cfg)
-	require.NoError(t, err)
-	return restClient
 }
 
 func testCacheAdapter[F runtime.Object, T entity.HasMetadata](
@@ -162,32 +160,4 @@ func waitUntilPresent(timeout time.Duration, targetFunc func() bool) bool {
 			}
 		}
 	}
-}
-
-func TestStartGatewayRouteCacheAdapter_Forbidden(t *testing.T) {
-	ctx := context.Background()
-	watchExecutor := &testWatchExecutor{mutex: &sync.Mutex{}, watchers: map[int]watchReturnFunc{
-		0: func() (watch.Interface, error) {
-			return nil, apierrors.NewForbidden(
-				schema.GroupResource{Resource: "httproutes"},
-				"test",
-				errors.New("forbidden"),
-			)
-		},
-	}}
-
-	clientset := fake.NewClientset()
-	certClientSet := &certClient.Clientset{}
-	watchHandlers := NewSharedWatchEventHandlers(watchExecutor, watchTimeout,
-		clientset.CoreV1().RESTClient(),
-		certClientSet.CertmanagerV1().RESTClient(),
-		clientset.NetworkingV1().RESTClient(),
-		clientset.ExtensionsV1beta1().RESTClient(),
-	)
-	watchHandlers.WithHTTPRouteV1(watchExecutor, watchTimeout, testGatewayRESTClient(t))
-
-	resourcesCache := cache.NewTestResourcesCache(cache.HttpRouteCache)
-	adapter, err := startGatewayRouteCacheAdapter(ctx, testNamespace1, resourcesCache.HTTPRoute, watchHandlers.HTTPRouteV1, "httproutes")
-	require.NoError(t, err)
-	require.Nil(t, adapter)
 }

--- a/service/internal/kubernetes/adapterForCache_test.go
+++ b/service/internal/kubernetes/adapterForCache_test.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"sync"
 	"testing"
@@ -12,11 +13,14 @@ import (
 	"github.com/netcracker/qubership-core-lib-go-paas-mediation-client/v8/service/internal/cache"
 	"github.com/netcracker/qubership-core-lib-go/v3/logging"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	fakeWatch "k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes"
-	gatewayv1 "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/typed/apis/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 )
 
 func TestCacheAdapters(t *testing.T) {
@@ -27,8 +31,6 @@ func TestCacheAdapters(t *testing.T) {
 		cache.ServiceCache,
 		cache.SecretCache,
 		cache.RouteCache,
-		cache.HttpRouteCache,
-		cache.GrpcRouteCache,
 		//cache.CertificateCache, //todo not supported yet
 	} {
 
@@ -40,16 +42,16 @@ func TestCacheAdapters(t *testing.T) {
 			0: func() (fakeWatch.Interface, error) { return watchExecutor1, nil },
 		}}
 
-		clientset := &kubernetes.Clientset{}
+		clientset := fake.NewClientset()
 		cert_client := &certClient.Clientset{}
-		gatewayClient := &gatewayv1.GatewayV1Client{}
+		gatewayREST := clientset.CoreV1().RESTClient()
 		watchHandlers := NewSharedWatchEventHandlers(watchExecutor, watchTimeout,
 			clientset.CoreV1().RESTClient(),
 			cert_client.CertmanagerV1().RESTClient(),
 			clientset.NetworkingV1().RESTClient(),
 			clientset.ExtensionsV1beta1().RESTClient())
-		watchHandlers.WithHTTPRouteV1(watchExecutor, watchTimeout, gatewayClient.RESTClient())
-		watchHandlers.WithGRPCRouteV1(watchExecutor, watchTimeout, gatewayClient.RESTClient())
+		watchHandlers.WithHTTPRouteV1(watchExecutor, watchTimeout, gatewayREST)
+		watchHandlers.WithGRPCRouteV1(watchExecutor, watchTimeout, gatewayREST)
 		resourcesCache := cache.NewTestResourcesCache(cacheType)
 		cacheAdapters, err := NewCacheAdapters(ctx, testNamespace1, resourcesCache, watchHandlers)
 		assertions.NoError(err)
@@ -93,22 +95,22 @@ func TestCacheAdapters(t *testing.T) {
 			resourceCache := resourcesCache.Certificates
 			assertions.NotNil(resourceCache)
 			testCacheAdapter(ctx, t, testResourceName, resourceAdded, resourceModified, resourceDeleted, entity.NewCertificate, resourceCache, watchExecutor1)
-		case cache.HttpRouteCache:
-			resourceAdded := createHttpRoute(testResourceName, 1, "1")
-			resourceModified := createHttpRoute(testResourceName, 2, "2")
-			resourceDeleted := createHttpRoute(testResourceName, 2, "3")
-			resourceCache := resourcesCache.HTTPRoute
-			assertions.NotNil(resourceCache)
-			testCacheAdapter(ctx, t, testResourceName, resourceAdded, resourceModified, resourceDeleted, entity.RouteFromHTTPRoute, resourceCache, watchExecutor1)
-		case cache.GrpcRouteCache:
-			resourceAdded := createGrpcRoute(testResourceName, 1, "1")
-			resourceModified := createGrpcRoute(testResourceName, 2, "2")
-			resourceDeleted := createGrpcRoute(testResourceName, 2, "3")
-			resourceCache := resourcesCache.GRPCRoute
-			assertions.NotNil(resourceCache)
-			testCacheAdapter(ctx, t, testResourceName, resourceAdded, resourceModified, resourceDeleted, entity.RouteFromGRPCRoute, resourceCache, watchExecutor1)
 		}
 	}
+}
+
+func testGatewayRESTClient(t *testing.T) rest.Interface {
+	t.Helper()
+	cfg := &rest.Config{
+		Host: "https://127.0.0.1:6443",
+		ContentConfig: rest.ContentConfig{
+			GroupVersion:         &schema.GroupVersion{Group: "gateway.networking.k8s.io", Version: "v1"},
+			NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+		},
+	}
+	restClient, err := rest.RESTClientFor(cfg)
+	require.NoError(t, err)
+	return restClient
 }
 
 func testCacheAdapter[F runtime.Object, T entity.HasMetadata](
@@ -160,4 +162,32 @@ func waitUntilPresent(timeout time.Duration, targetFunc func() bool) bool {
 			}
 		}
 	}
+}
+
+func TestStartGatewayRouteCacheAdapter_Forbidden(t *testing.T) {
+	ctx := context.Background()
+	watchExecutor := &testWatchExecutor{mutex: &sync.Mutex{}, watchers: map[int]watchReturnFunc{
+		0: func() (watch.Interface, error) {
+			return nil, apierrors.NewForbidden(
+				schema.GroupResource{Resource: "httproutes"},
+				"test",
+				errors.New("forbidden"),
+			)
+		},
+	}}
+
+	clientset := fake.NewClientset()
+	certClientSet := &certClient.Clientset{}
+	watchHandlers := NewSharedWatchEventHandlers(watchExecutor, watchTimeout,
+		clientset.CoreV1().RESTClient(),
+		certClientSet.CertmanagerV1().RESTClient(),
+		clientset.NetworkingV1().RESTClient(),
+		clientset.ExtensionsV1beta1().RESTClient(),
+	)
+	watchHandlers.WithHTTPRouteV1(watchExecutor, watchTimeout, testGatewayRESTClient(t))
+
+	resourcesCache := cache.NewTestResourcesCache(cache.HttpRouteCache)
+	adapter, err := startGatewayRouteCacheAdapter(ctx, testNamespace1, resourcesCache.HTTPRoute, watchHandlers.HTTPRouteV1, "httproutes")
+	require.NoError(t, err)
+	require.Nil(t, adapter)
 }

--- a/service/internal/kubernetes/gateway_system.go
+++ b/service/internal/kubernetes/gateway_system.go
@@ -23,14 +23,14 @@ type GatewaySystem struct {
 	Name      string
 }
 
-func (g GatewaySystem) ShouldUseGatewayAPI() bool {
+func (g GatewaySystem) IsGatewayAPIEnabled() bool {
 	if g.Type == "" {
 		return false
 	}
 	return strings.Contains(g.Type, GatewayApiDefault)
 }
 
-func (g GatewaySystem) ShouldCreateLegacyIngress() bool {
+func (g GatewaySystem) IsIngressEnabled() bool {
 	if g.Type == "" {
 		return true
 	}
@@ -45,7 +45,7 @@ func (g GatewaySystem) IsBothGatewaySystemsEnabled() bool {
 }
 
 func (g GatewaySystem) IsRouteCreationAllowed() bool {
-	return g.ShouldUseGatewayAPI() || g.ShouldCreateLegacyIngress()
+	return g.IsGatewayAPIEnabled() || g.IsIngressEnabled()
 }
 
 func (g GatewaySystem) RouteCreationNotAllowedError() error {

--- a/service/internal/kubernetes/gateway_system.go
+++ b/service/internal/kubernetes/gateway_system.go
@@ -1,0 +1,38 @@
+package kubernetes
+
+import "strings"
+
+const (
+	LegacyIngress     = "legacy-ingress"
+	GatewayApiDefault = "gateway-api-default"
+
+	DefaultGatewaySystemNamespace = "gateway-system"
+	DefaultGatewaySystemName      = "default-external-gateway"
+)
+
+type GatewaySystem struct {
+	Type      string
+	Namespace string
+	Name      string
+}
+
+func (g GatewaySystem) ShouldUseGatewayAPI() bool {
+	if g.Type == "" {
+		return false
+	}
+	return strings.Contains(g.Type, GatewayApiDefault)
+}
+
+func (g GatewaySystem) ShouldCreateLegacyIngress() bool {
+	if g.Type == "" {
+		return true
+	}
+	return strings.Contains(g.Type, LegacyIngress)
+}
+
+func (g GatewaySystem) ShouldIgnoreIngressForConverter() bool {
+	if g.Type == "" {
+		return false
+	}
+	return strings.Contains(g.Type, LegacyIngress) && strings.Contains(g.Type, GatewayApiDefault)
+}

--- a/service/internal/kubernetes/gateway_system.go
+++ b/service/internal/kubernetes/gateway_system.go
@@ -1,6 +1,9 @@
 package kubernetes
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 const (
 	LegacyIngress     = "legacy-ingress"
@@ -8,6 +11,10 @@ const (
 
 	DefaultGatewaySystemNamespace = "gateway-system"
 	DefaultGatewaySystemName      = "default-external-gateway"
+
+	GatewaySystemTypeProperty      = "gateway.system.type"
+	GatewaySystemNamespaceProperty = "gateway.system.namespace"
+	GatewaySystemNameProperty      = "gateway.system.name"
 )
 
 type GatewaySystem struct {
@@ -30,9 +37,21 @@ func (g GatewaySystem) ShouldCreateLegacyIngress() bool {
 	return strings.Contains(g.Type, LegacyIngress)
 }
 
-func (g GatewaySystem) ShouldIgnoreIngressForConverter() bool {
+func (g GatewaySystem) IsBothGatewaySystemsEnabled() bool {
 	if g.Type == "" {
 		return false
 	}
 	return strings.Contains(g.Type, LegacyIngress) && strings.Contains(g.Type, GatewayApiDefault)
+}
+
+func (g GatewaySystem) IsRouteCreationAllowed() bool {
+	return g.ShouldUseGatewayAPI() || g.ShouldCreateLegacyIngress()
+}
+
+func (g GatewaySystem) RouteCreationNotAllowedError() error {
+	return fmt.Errorf("GATEWAY_SYSTEM_TYPE=%s does not allow any Route creation", g.Type)
+}
+
+func (g GatewaySystem) RouteUpdateNotAllowedError() error {
+	return fmt.Errorf("GATEWAY_SYSTEM_TYPE=%s does not allow any Route update", g.Type)
 }

--- a/service/internal/kubernetes/kubeService.go
+++ b/service/internal/kubernetes/kubeService.go
@@ -136,12 +136,7 @@ type KubernetesClientBuilder struct {
 }
 
 func NewKubernetesClientBuilder() *KubernetesClientBuilder {
-	return &KubernetesClientBuilder{
-		gatewaySystem: GatewaySystem{
-			Namespace: DefaultGatewaySystemNamespace,
-			Name:      DefaultGatewaySystemName,
-		},
-	}
+	return &KubernetesClientBuilder{}
 }
 
 func (b *KubernetesClientBuilder) WithNamespace(namespace string) *KubernetesClientBuilder {
@@ -214,6 +209,13 @@ func (b *KubernetesClientBuilder) applyDefaults() {
 	}
 	if b.cache == nil {
 		b.cache = &cache.ResourcesCache{} // set empty cache
+	}
+
+	if b.gatewaySystem.Namespace == "" {
+		b.gatewaySystem.Namespace = DefaultGatewaySystemNamespace
+	}
+	if b.gatewaySystem.Name == "" {
+		b.gatewaySystem.Name = DefaultGatewaySystemName
 	}
 }
 

--- a/service/internal/kubernetes/kubeService.go
+++ b/service/internal/kubernetes/kubeService.go
@@ -244,34 +244,25 @@ func canWatchGatewayResource(client kubernetes.Interface, namespace, resource st
 	return result.Status.Allowed, true
 }
 
-type gatewayRouteRegistrar func(handlers *SharedWatchHandlers, executor pmWatch.Executor, clientTimeout time.Duration, restClient rest.Interface)
-
 func (b *KubernetesClientBuilder) enrichWatchHandlersWithGatewayRoutes(handlers *SharedWatchHandlers) error {
 	kubeDiscovery := b.client.KubernetesInterface.Discovery()
 	authClient := b.client.KubernetesInterface
 
 	if hasKindGatewayApi("HTTPRoute", kubeDiscovery) {
-		b.registerGatewayRouteWatchHandler(handlers, authClient, "HTTPRoute", "httproutes",
-			func(h *SharedWatchHandlers, executor pmWatch.Executor, clientTimeout time.Duration, restClient rest.Interface) {
-				h.WithHTTPRouteV1(executor, clientTimeout, restClient)
-			})
+		b.registerGatewayRouteWatchHandler(authClient, "HTTPRoute", "httproutes", handlers.WithHTTPRouteV1)
 	}
 
 	if hasKindGatewayApi("GRPCRoute", kubeDiscovery) {
-		b.registerGatewayRouteWatchHandler(handlers, authClient, "GRPCRoute", "grpcroutes",
-			func(h *SharedWatchHandlers, executor pmWatch.Executor, clientTimeout time.Duration, restClient rest.Interface) {
-				h.WithGRPCRouteV1(executor, clientTimeout, restClient)
-			})
+		b.registerGatewayRouteWatchHandler(authClient, "GRPCRoute", "grpcroutes", handlers.WithGRPCRouteV1)
 	}
 
 	return nil
 }
 
 func (b *KubernetesClientBuilder) registerGatewayRouteWatchHandler(
-	handlers *SharedWatchHandlers,
 	authClient kubernetes.Interface,
 	kind, resource string,
-	register gatewayRouteRegistrar,
+	register func(executor pmWatch.Executor, clientTimeout time.Duration, restClient rest.Interface),
 ) {
 	allowed, checked := canWatchGatewayResource(authClient, b.namespace, resource)
 	if checked && !allowed {
@@ -288,7 +279,7 @@ func (b *KubernetesClientBuilder) registerGatewayRouteWatchHandler(
 		logger.Errorf("failed to install Gateway API scheme for %s watch: %v", kind, err)
 		return
 	}
-	register(handlers, b.watchExecutor, b.watchClientTimeout, restClient)
+	register(b.watchExecutor, b.watchClientTimeout, restClient)
 }
 
 func gatewayRESTClient(client *backend.KubernetesApi) rest.Interface {

--- a/service/internal/kubernetes/kubeService.go
+++ b/service/internal/kubernetes/kubeService.go
@@ -15,13 +15,16 @@ import (
 	pmWatch "github.com/netcracker/qubership-core-lib-go-paas-mediation-client/v8/watch"
 	"github.com/netcracker/qubership-core-lib-go/v3/logging"
 	"golang.org/x/mod/semver"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	appsv1_client "k8s.io/client-go/kubernetes/typed/apps/v1"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	extensionsv1beta1 "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
 	networkingv1 "k8s.io/client-go/kubernetes/typed/networking/v1"
+	"k8s.io/client-go/rest"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1_client "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/typed/apis/v1"
 )
@@ -212,24 +215,93 @@ func (b *KubernetesClientBuilder) applyDefaults() {
 	}
 }
 
+func (b *KubernetesClientBuilder) needsGatewayRoutesWatchers() bool {
+	if b.cache == nil {
+		return false
+	}
+	return b.cache.HTTPRoute != nil || b.cache.GRPCRoute != nil
+}
+
+func canWatchGatewayResource(client kubernetes.Interface, namespace, resource string) (allowed bool, checked bool) {
+	review := &authorizationv1.SelfSubjectAccessReview{
+		Spec: authorizationv1.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authorizationv1.ResourceAttributes{
+				Namespace: namespace,
+				Verb:      "watch",
+				Group:     "gateway.networking.k8s.io",
+				Version:   "v1",
+				Resource:  resource,
+			},
+		},
+	}
+	result, err := client.AuthorizationV1().SelfSubjectAccessReviews().Create(context.Background(), review, v1.CreateOptions{})
+	if err != nil {
+		logger.Warnf("cannot verify RBAC for gateway %s watch in namespace %s: %v", resource, namespace, err)
+		return false, false
+	}
+	return result.Status.Allowed, true
+}
+
 func (b *KubernetesClientBuilder) enrichWatchHandlersWithGatewayRoutes(handlers *SharedWatchHandlers) error {
+	if !b.needsGatewayRoutesWatchers() {
+		return nil
+	}
+
 	discovery := b.client.KubernetesInterface.Discovery()
+	authClient := b.client.KubernetesInterface
 
 	if hasKindGatewayApi("HTTPRoute", discovery) {
-		if err := gatewayv1.Install(scheme.Scheme); err != nil {
-			return err
-		}
-		handlers.WithHTTPRouteV1(b.watchExecutor, b.watchClientTimeout, b.client.GatewayV1().RESTClient())
+		b.registerHTTPRouteWatchHandler(handlers, authClient)
 	}
 
 	if hasKindGatewayApi("GRPCRoute", discovery) {
-		if err := gatewayv1.Install(scheme.Scheme); err != nil {
-			return err
-		}
-		handlers.WithGRPCRouteV1(b.watchExecutor, b.watchClientTimeout, b.client.GatewayV1().RESTClient())
+		b.registerGRPCRouteWatchHandler(handlers, authClient)
 	}
 
 	return nil
+}
+
+func (b *KubernetesClientBuilder) registerHTTPRouteWatchHandler(handlers *SharedWatchHandlers, authClient kubernetes.Interface) {
+	allowed, checked := canWatchGatewayResource(authClient, b.namespace, "httproutes")
+	if checked && !allowed {
+		logger.Warn("HTTPRoute API is available but ServiceAccount cannot watch httproutes in namespace '%s'; HTTPRoute cache watch is disabled", b.namespace)
+		return
+	}
+	restClient := gatewayRESTClient(b.client)
+	if restClient == nil {
+		logger.Warn("HTTPRoute cache is enabled but Gateway API REST client is not available; HTTPRoute watch is disabled")
+		return
+	}
+	if err := gatewayv1.Install(scheme.Scheme); err != nil {
+		logger.Errorf("failed to install Gateway API scheme for HTTPRoute watch: %v", err)
+		return
+	}
+	handlers.WithHTTPRouteV1(b.watchExecutor, b.watchClientTimeout, restClient)
+}
+
+func (b *KubernetesClientBuilder) registerGRPCRouteWatchHandler(handlers *SharedWatchHandlers, authClient kubernetes.Interface) {
+	allowed, checked := canWatchGatewayResource(authClient, b.namespace, "grpcroutes")
+	if checked && !allowed {
+		logger.Warn("GRPCRoute API is available but ServiceAccount cannot watch grpcroutes in namespace '%s'; GRPCRoute cache watch is disabled", b.namespace)
+		return
+	}
+	restClient := gatewayRESTClient(b.client)
+	if restClient == nil {
+		logger.Warn("GRPCRoute cache is enabled but Gateway API REST client is not available; GRPCRoute watch is disabled")
+		return
+	}
+	if err := gatewayv1.Install(scheme.Scheme); err != nil {
+		logger.Errorf("failed to install Gateway API scheme for GRPCRoute watch: %v", err)
+		return
+	}
+	handlers.WithGRPCRouteV1(b.watchExecutor, b.watchClientTimeout, restClient)
+}
+
+func gatewayRESTClient(client *backend.KubernetesApi) rest.Interface {
+	if client == nil || client.GatewayV1() == nil {
+		return nil
+	}
+	return client.GatewayV1().RESTClient()
 }
 
 func resolveGatewaySystemConfig(namespace, name string) (string, string) {

--- a/service/internal/kubernetes/kubeService.go
+++ b/service/internal/kubernetes/kubeService.go
@@ -251,13 +251,16 @@ func (b *KubernetesClientBuilder) enrichWatchHandlersWithGatewayRoutes(handlers 
 	authClient := b.client.KubernetesInterface
 
 	if hasKindGatewayApi("HTTPRoute", kubeDiscovery) {
-		b.registerGatewayRouteWatchHandler(authClient, "HTTPRoute", "httproutes", handlers.WithHTTPRouteV1)
+		if err := b.registerGatewayRouteWatchHandler(authClient, "HTTPRoute", "httproutes", handlers.WithHTTPRouteV1); err != nil {
+			return err
+		}
 	}
 
 	if hasKindGatewayApi("GRPCRoute", kubeDiscovery) {
-		b.registerGatewayRouteWatchHandler(authClient, "GRPCRoute", "grpcroutes", handlers.WithGRPCRouteV1)
+		if err := b.registerGatewayRouteWatchHandler(authClient, "GRPCRoute", "grpcroutes", handlers.WithGRPCRouteV1); err != nil {
+			return err
+		}
 	}
-
 	return nil
 }
 
@@ -265,23 +268,23 @@ func (b *KubernetesClientBuilder) registerGatewayRouteWatchHandler(
 	authClient kubernetes.Interface,
 	kind, resource string,
 	register func(executor pmWatch.Executor, clientTimeout time.Duration, restClient rest.Interface),
-) {
+) error {
 	allowed, checked := canWatchGatewayResource(authClient, b.namespace, resource)
 	if checked && !allowed {
 		logger.Warn("%s API is available but ServiceAccount cannot watch %s in namespace '%s'; %s cache watch is disabled",
 			kind, resource, b.namespace, kind)
-		return
+		return nil
 	}
 	restClient := gatewayRESTClient(b.client)
 	if restClient == nil {
 		logger.Warn("%s cache is enabled but Gateway API REST client is not available; %s watch is disabled", kind, kind)
-		return
+		return nil
 	}
 	if err := gatewayv1.Install(scheme.Scheme); err != nil {
-		logger.Errorf("failed to install Gateway API scheme for %s watch: %v", kind, err)
-		return
+		return err
 	}
 	register(b.watchExecutor, b.watchClientTimeout, restClient)
+	return nil
 }
 
 func gatewayRESTClient(client *backend.KubernetesApi) rest.Interface {

--- a/service/internal/kubernetes/kubeService.go
+++ b/service/internal/kubernetes/kubeService.go
@@ -194,13 +194,7 @@ func (b *KubernetesClientBuilder) WithGatewaySystemName(name string) *Kubernetes
 	return b
 }
 
-func (b *KubernetesClientBuilder) Build() (*Kubernetes, error) {
-	if b.namespace == "" {
-		return nil, fmt.Errorf("namespace cannot be empty")
-	}
-	if b.client == nil {
-		return nil, fmt.Errorf("client cannot be nil")
-	}
+func (b *KubernetesClientBuilder) applyDefaults() {
 	if b.watchExecutor == nil {
 		b.watchExecutor = &DefaultWatchExecutor{}
 	}
@@ -216,6 +210,47 @@ func (b *KubernetesClientBuilder) Build() (*Kubernetes, error) {
 	if b.cache == nil {
 		b.cache = &cache.ResourcesCache{} // set empty cache
 	}
+}
+
+func (b *KubernetesClientBuilder) enrichWatchHandlersWithGatewayRoutes(handlers *SharedWatchHandlers) error {
+	discovery := b.client.KubernetesInterface.Discovery()
+
+	if hasKindGatewayApi("HTTPRoute", discovery) {
+		if err := gatewayv1.Install(scheme.Scheme); err != nil {
+			return err
+		}
+		handlers.WithHTTPRouteV1(b.watchExecutor, b.watchClientTimeout, b.client.GatewayV1().RESTClient())
+	}
+
+	if hasKindGatewayApi("GRPCRoute", discovery) {
+		if err := gatewayv1.Install(scheme.Scheme); err != nil {
+			return err
+		}
+		handlers.WithGRPCRouteV1(b.watchExecutor, b.watchClientTimeout, b.client.GatewayV1().RESTClient())
+	}
+
+	return nil
+}
+
+func resolveGatewaySystemConfig(namespace, name string) (string, string) {
+	if namespace == "" {
+		namespace = "gateway-system"
+	}
+	if name == "" {
+		name = "default-external-gateway"
+	}
+	return namespace, name
+}
+
+func (b *KubernetesClientBuilder) Build() (*Kubernetes, error) {
+	if b.namespace == "" {
+		return nil, fmt.Errorf("namespace cannot be empty")
+	}
+	if b.client == nil {
+		return nil, fmt.Errorf("client cannot be nil")
+	}
+	b.applyDefaults()
+
 	version, err := b.client.KubernetesInterface.Discovery().ServerVersion()
 	if err != nil {
 		return nil, err
@@ -230,20 +265,8 @@ func (b *KubernetesClientBuilder) Build() (*Kubernetes, error) {
 		b.client.NetworkingV1().RESTClient(),
 		b.client.ExtensionsV1beta1().RESTClient(),
 	)
-	if hasKindGatewayApi("HTTPRoute", b.client.KubernetesInterface.Discovery()) {
-		err := gatewayv1.Install(scheme.Scheme)
-		if err != nil {
-			return nil, err
-		}
-		watchEventHandlers.WithHTTPRouteV1(b.watchExecutor, b.watchClientTimeout, b.client.GatewayV1().RESTClient())
-	}
-
-	if hasKindGatewayApi("GRPCRoute", b.client.KubernetesInterface.Discovery()) {
-		err := gatewayv1.Install(scheme.Scheme)
-		if err != nil {
-			return nil, err
-		}
-		watchEventHandlers.WithGRPCRouteV1(b.watchExecutor, b.watchClientTimeout, b.client.GatewayV1().RESTClient())
+	if err := b.enrichWatchHandlersWithGatewayRoutes(watchEventHandlers); err != nil {
+		return nil, err
 	}
 
 	ctx := context.Background() //todo make all parent functions to pass context, this context will be able to cancel everything inside Kubernetes srv when it's no longer needed
@@ -252,14 +275,7 @@ func (b *KubernetesClientBuilder) Build() (*Kubernetes, error) {
 		return nil, err
 	}
 
-	gatewaySystemNamespace := b.gatewaySystemNamespace
-	if gatewaySystemNamespace == "" {
-		gatewaySystemNamespace = "gateway-system"
-	}
-	gatewaySystemName := b.gatewaySystemName
-	if gatewaySystemName == "" {
-		gatewaySystemName = "default-external-gateway"
-	}
+	gatewaySystemNamespace, gatewaySystemName := resolveGatewaySystemConfig(b.gatewaySystemNamespace, b.gatewaySystemName)
 
 	return &Kubernetes{
 		initCacheOnce:          sync.Once{},

--- a/service/internal/kubernetes/kubeService.go
+++ b/service/internal/kubernetes/kubeService.go
@@ -56,6 +56,9 @@ type Kubernetes struct {
 	UseNetworkingV1Ingress bool          // todo remove it in the nex major release if we don't support k8s 1.22 anymore
 	RolloutExecutor        exec.RolloutExecutor
 	BG2Enabled             func() bool
+	GatewaySystemType      string
+	GatewaySystemNamespace string
+	GatewaySystemName      string
 }
 
 // todo delete this in next major release!
@@ -119,14 +122,17 @@ func (r *BadRoutes) ToSliceMap() (result map[string][]string) {
 }
 
 type KubernetesClientBuilder struct {
-	namespace          string
-	client             *backend.KubernetesApi
-	watchExecutor      pmWatch.Executor
-	watchClientTimeout time.Duration
-	cache              *cache.ResourcesCache
-	badResources       *BadResources
-	rolloutExecutor    exec.RolloutExecutor
-	bg2Enabled         func() bool
+	namespace              string
+	client                 *backend.KubernetesApi
+	watchExecutor          pmWatch.Executor
+	watchClientTimeout     time.Duration
+	cache                  *cache.ResourcesCache
+	badResources           *BadResources
+	rolloutExecutor        exec.RolloutExecutor
+	bg2Enabled             func() bool
+	gatewaySystemType      string
+	gatewaySystemNamespace string
+	gatewaySystemName      string
 }
 
 func NewKubernetesClientBuilder() *KubernetesClientBuilder {
@@ -170,6 +176,21 @@ func (b *KubernetesClientBuilder) WithRolloutExecutor(rolloutExecutor exec.Rollo
 
 func (b *KubernetesClientBuilder) WithBG2Enabled(enabled func() bool) *KubernetesClientBuilder {
 	b.bg2Enabled = enabled
+	return b
+}
+
+func (b *KubernetesClientBuilder) WithGatewaySystemType(gatewaySystemType string) *KubernetesClientBuilder {
+	b.gatewaySystemType = gatewaySystemType
+	return b
+}
+
+func (b *KubernetesClientBuilder) WithGatewaySystemNamespace(namespace string) *KubernetesClientBuilder {
+	b.gatewaySystemNamespace = namespace
+	return b
+}
+
+func (b *KubernetesClientBuilder) WithGatewaySystemName(name string) *KubernetesClientBuilder {
+	b.gatewaySystemName = name
 	return b
 }
 
@@ -230,6 +251,16 @@ func (b *KubernetesClientBuilder) Build() (*Kubernetes, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	gatewaySystemNamespace := b.gatewaySystemNamespace
+	if gatewaySystemNamespace == "" {
+		gatewaySystemNamespace = "gateway-system"
+	}
+	gatewaySystemName := b.gatewaySystemName
+	if gatewaySystemName == "" {
+		gatewaySystemName = "default-external-gateway"
+	}
+
 	return &Kubernetes{
 		initCacheOnce:          sync.Once{},
 		client:                 b.client,
@@ -242,6 +273,9 @@ func (b *KubernetesClientBuilder) Build() (*Kubernetes, error) {
 		UseNetworkingV1Ingress: useNetworkingV1Ingress,
 		RolloutExecutor:        b.rolloutExecutor,
 		BG2Enabled:             b.bg2Enabled,
+		GatewaySystemType:      b.gatewaySystemType,
+		GatewaySystemNamespace: gatewaySystemNamespace,
+		GatewaySystemName:      gatewaySystemName,
 	}, nil
 }
 

--- a/service/internal/kubernetes/kubeService.go
+++ b/service/internal/kubernetes/kubeService.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"sync"
 	"time"
 
@@ -59,9 +60,7 @@ type Kubernetes struct {
 	UseNetworkingV1Ingress bool          // todo remove it in the nex major release if we don't support k8s 1.22 anymore
 	RolloutExecutor        exec.RolloutExecutor
 	BG2Enabled             func() bool
-	GatewaySystemType      string
-	GatewaySystemNamespace string
-	GatewaySystemName      string
+	GatewaySystem          GatewaySystem
 }
 
 // todo delete this in next major release!
@@ -125,21 +124,24 @@ func (r *BadRoutes) ToSliceMap() (result map[string][]string) {
 }
 
 type KubernetesClientBuilder struct {
-	namespace              string
-	client                 *backend.KubernetesApi
-	watchExecutor          pmWatch.Executor
-	watchClientTimeout     time.Duration
-	cache                  *cache.ResourcesCache
-	badResources           *BadResources
-	rolloutExecutor        exec.RolloutExecutor
-	bg2Enabled             func() bool
-	gatewaySystemType      string
-	gatewaySystemNamespace string
-	gatewaySystemName      string
+	namespace          string
+	client             *backend.KubernetesApi
+	watchExecutor      pmWatch.Executor
+	watchClientTimeout time.Duration
+	cache              *cache.ResourcesCache
+	badResources       *BadResources
+	rolloutExecutor    exec.RolloutExecutor
+	bg2Enabled         func() bool
+	gatewaySystem      GatewaySystem
 }
 
 func NewKubernetesClientBuilder() *KubernetesClientBuilder {
-	return &KubernetesClientBuilder{}
+	return &KubernetesClientBuilder{
+		gatewaySystem: GatewaySystem{
+			Namespace: DefaultGatewaySystemNamespace,
+			Name:      DefaultGatewaySystemName,
+		},
+	}
 }
 
 func (b *KubernetesClientBuilder) WithNamespace(namespace string) *KubernetesClientBuilder {
@@ -183,17 +185,17 @@ func (b *KubernetesClientBuilder) WithBG2Enabled(enabled func() bool) *Kubernete
 }
 
 func (b *KubernetesClientBuilder) WithGatewaySystemType(gatewaySystemType string) *KubernetesClientBuilder {
-	b.gatewaySystemType = gatewaySystemType
+	b.gatewaySystem.Type = gatewaySystemType
 	return b
 }
 
 func (b *KubernetesClientBuilder) WithGatewaySystemNamespace(namespace string) *KubernetesClientBuilder {
-	b.gatewaySystemNamespace = namespace
+	b.gatewaySystem.Namespace = namespace
 	return b
 }
 
 func (b *KubernetesClientBuilder) WithGatewaySystemName(name string) *KubernetesClientBuilder {
-	b.gatewaySystemName = name
+	b.gatewaySystem.Name = name
 	return b
 }
 
@@ -242,76 +244,62 @@ func canWatchGatewayResource(client kubernetes.Interface, namespace, resource st
 	return result.Status.Allowed, true
 }
 
-func (b *KubernetesClientBuilder) enrichWatchHandlersWithGatewayRoutes(handlers *SharedWatchHandlers) error {
-	if !b.needsGatewayRoutesWatchers() {
-		return nil
-	}
+type gatewayRouteRegistrar func(handlers *SharedWatchHandlers, executor pmWatch.Executor, clientTimeout time.Duration, restClient rest.Interface)
 
-	discovery := b.client.KubernetesInterface.Discovery()
+func (b *KubernetesClientBuilder) enrichWatchHandlersWithGatewayRoutes(handlers *SharedWatchHandlers) error {
+	kubeDiscovery := b.client.KubernetesInterface.Discovery()
 	authClient := b.client.KubernetesInterface
 
-	if hasKindGatewayApi("HTTPRoute", discovery) {
-		b.registerHTTPRouteWatchHandler(handlers, authClient)
+	if hasKindGatewayApi("HTTPRoute", kubeDiscovery) {
+		b.registerGatewayRouteWatchHandler(handlers, authClient, "HTTPRoute", "httproutes",
+			func(h *SharedWatchHandlers, executor pmWatch.Executor, clientTimeout time.Duration, restClient rest.Interface) {
+				h.WithHTTPRouteV1(executor, clientTimeout, restClient)
+			})
 	}
 
-	if hasKindGatewayApi("GRPCRoute", discovery) {
-		b.registerGRPCRouteWatchHandler(handlers, authClient)
+	if hasKindGatewayApi("GRPCRoute", kubeDiscovery) {
+		b.registerGatewayRouteWatchHandler(handlers, authClient, "GRPCRoute", "grpcroutes",
+			func(h *SharedWatchHandlers, executor pmWatch.Executor, clientTimeout time.Duration, restClient rest.Interface) {
+				h.WithGRPCRouteV1(executor, clientTimeout, restClient)
+			})
 	}
 
 	return nil
 }
 
-func (b *KubernetesClientBuilder) registerHTTPRouteWatchHandler(handlers *SharedWatchHandlers, authClient kubernetes.Interface) {
-	allowed, checked := canWatchGatewayResource(authClient, b.namespace, "httproutes")
+func (b *KubernetesClientBuilder) registerGatewayRouteWatchHandler(
+	handlers *SharedWatchHandlers,
+	authClient kubernetes.Interface,
+	kind, resource string,
+	register gatewayRouteRegistrar,
+) {
+	allowed, checked := canWatchGatewayResource(authClient, b.namespace, resource)
 	if checked && !allowed {
-		logger.Warn("HTTPRoute API is available but ServiceAccount cannot watch httproutes in namespace '%s'; HTTPRoute cache watch is disabled", b.namespace)
+		logger.Warn("%s API is available but ServiceAccount cannot watch %s in namespace '%s'; %s cache watch is disabled",
+			kind, resource, b.namespace, kind)
 		return
 	}
 	restClient := gatewayRESTClient(b.client)
 	if restClient == nil {
-		logger.Warn("HTTPRoute cache is enabled but Gateway API REST client is not available; HTTPRoute watch is disabled")
+		logger.Warn("%s cache is enabled but Gateway API REST client is not available; %s watch is disabled", kind, kind)
 		return
 	}
 	if err := gatewayv1.Install(scheme.Scheme); err != nil {
-		logger.Errorf("failed to install Gateway API scheme for HTTPRoute watch: %v", err)
+		logger.Errorf("failed to install Gateway API scheme for %s watch: %v", kind, err)
 		return
 	}
-	handlers.WithHTTPRouteV1(b.watchExecutor, b.watchClientTimeout, restClient)
-}
-
-func (b *KubernetesClientBuilder) registerGRPCRouteWatchHandler(handlers *SharedWatchHandlers, authClient kubernetes.Interface) {
-	allowed, checked := canWatchGatewayResource(authClient, b.namespace, "grpcroutes")
-	if checked && !allowed {
-		logger.Warn("GRPCRoute API is available but ServiceAccount cannot watch grpcroutes in namespace '%s'; GRPCRoute cache watch is disabled", b.namespace)
-		return
-	}
-	restClient := gatewayRESTClient(b.client)
-	if restClient == nil {
-		logger.Warn("GRPCRoute cache is enabled but Gateway API REST client is not available; GRPCRoute watch is disabled")
-		return
-	}
-	if err := gatewayv1.Install(scheme.Scheme); err != nil {
-		logger.Errorf("failed to install Gateway API scheme for GRPCRoute watch: %v", err)
-		return
-	}
-	handlers.WithGRPCRouteV1(b.watchExecutor, b.watchClientTimeout, restClient)
+	register(handlers, b.watchExecutor, b.watchClientTimeout, restClient)
 }
 
 func gatewayRESTClient(client *backend.KubernetesApi) rest.Interface {
 	if client == nil || client.GatewayV1() == nil {
 		return nil
 	}
-	return client.GatewayV1().RESTClient()
-}
-
-func resolveGatewaySystemConfig(namespace, name string) (string, string) {
-	if namespace == "" {
-		namespace = "gateway-system"
+	restClient := client.GatewayV1().RESTClient()
+	if restClient == nil || reflect.ValueOf(restClient).IsNil() {
+		return nil
 	}
-	if name == "" {
-		name = "default-external-gateway"
-	}
-	return namespace, name
+	return restClient
 }
 
 func (b *KubernetesClientBuilder) Build() (*Kubernetes, error) {
@@ -337,8 +325,10 @@ func (b *KubernetesClientBuilder) Build() (*Kubernetes, error) {
 		b.client.NetworkingV1().RESTClient(),
 		b.client.ExtensionsV1beta1().RESTClient(),
 	)
-	if err := b.enrichWatchHandlersWithGatewayRoutes(watchEventHandlers); err != nil {
-		return nil, err
+	if b.needsGatewayRoutesWatchers() {
+		if err := b.enrichWatchHandlersWithGatewayRoutes(watchEventHandlers); err != nil {
+			return nil, err
+		}
 	}
 
 	ctx := context.Background() //todo make all parent functions to pass context, this context will be able to cancel everything inside Kubernetes srv when it's no longer needed
@@ -346,8 +336,6 @@ func (b *KubernetesClientBuilder) Build() (*Kubernetes, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	gatewaySystemNamespace, gatewaySystemName := resolveGatewaySystemConfig(b.gatewaySystemNamespace, b.gatewaySystemName)
 
 	return &Kubernetes{
 		initCacheOnce:          sync.Once{},
@@ -361,9 +349,7 @@ func (b *KubernetesClientBuilder) Build() (*Kubernetes, error) {
 		UseNetworkingV1Ingress: useNetworkingV1Ingress,
 		RolloutExecutor:        b.rolloutExecutor,
 		BG2Enabled:             b.bg2Enabled,
-		GatewaySystemType:      b.gatewaySystemType,
-		GatewaySystemNamespace: gatewaySystemNamespace,
-		GatewaySystemName:      gatewaySystemName,
+		GatewaySystem:          b.gatewaySystem,
 	}, nil
 }
 

--- a/service/internal/kubernetes/kubeService_test.go
+++ b/service/internal/kubernetes/kubeService_test.go
@@ -420,55 +420,6 @@ func Test_WithoutCache(t *testing.T) {
 	assertions.NotNil(kubernetes.Cache)
 }
 
-func TestKubernetesClientBuilder_WithGatewaySystem(t *testing.T) {
-	assertions := require.New(t)
-	builder := NewKubernetesClientBuilder().
-		WithGatewaySystemType(GatewayApiDefault).
-		WithGatewaySystemNamespace("gw-ns").
-		WithGatewaySystemName("gw-name")
-	assertions.Equal(GatewayApiDefault, builder.gatewaySystem.Type)
-	assertions.Equal("gw-ns", builder.gatewaySystem.Namespace)
-	assertions.Equal("gw-name", builder.gatewaySystem.Name)
-}
-
-func Test_BuildSkipsEnrichWhenGatewayRouteCacheDisabled(t *testing.T) {
-	assertions := require.New(t)
-	namespace := v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace1}}
-	clientset := fake.NewClientset(&namespace)
-	kube, err := NewKubernetesClientBuilder().
-		WithNamespace(testNamespace1).
-		WithClient(&backend.KubernetesApi{KubernetesInterface: clientset, CertmanagerInterface: &certClient.Clientset{}}).
-		WithCache(cache.NewTestResourcesCache(cache.RouteCache)).
-		Build()
-	assertions.NoError(err)
-	assertions.Nil(kube.WatchHandlers.HTTPRouteV1)
-	assertions.Nil(kube.WatchHandlers.GRPCRouteV1)
-}
-
-func Test_BuildSkipsGatewayWatchWhenRBACDenied(t *testing.T) {
-	assertions := require.New(t)
-	k8sClient := fake.NewClientset()
-	k8sClient.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
-		review := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
-		review.Status = authorizationv1.SubjectAccessReviewStatus{Allowed: false}
-		return true, review, nil
-	})
-	fakeDisc := k8sClient.Discovery().(*fakediscovery.FakeDiscovery)
-	fakeDisc.Resources = []*metav1.APIResourceList{{
-		GroupVersion: "gateway.networking.k8s.io/v1",
-		APIResources: []metav1.APIResource{{Kind: "HTTPRoute"}},
-	}}
-	gwClient := gatewayclientfake.NewSimpleClientset()
-	kube, err := NewKubernetesClientBuilder().
-		WithNamespace(testNamespace1).
-		WithClient(newBuildTestKubernetesAPI(k8sClient, gwClient)).
-		WithWatchExecutor(newFakeWatchExecutor()).
-		WithCache(cache.NewTestResourcesCache(cache.HttpRouteCache)).
-		Build()
-	assertions.NoError(err)
-	assertions.Nil(kube.WatchHandlers.HTTPRouteV1)
-}
-
 func Test_BuildSetsGatewaySystemDefaults(t *testing.T) {
 	assertions := require.New(t)
 	namespace := v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace1}}

--- a/service/internal/kubernetes/kubeService_test.go
+++ b/service/internal/kubernetes/kubeService_test.go
@@ -22,13 +22,65 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	k8stesting "k8s.io/client-go/testing"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 	gatewayclientfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
+	gatewayv1client "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/typed/apis/v1"
 )
+
+type gatewayClientWithREST struct {
+	gatewayclient.Interface
+	restClient rest.Interface
+}
+
+func (c *gatewayClientWithREST) GatewayV1() gatewayv1client.GatewayV1Interface {
+	return &gatewayV1ClientWithREST{
+		GatewayV1Interface: c.Interface.GatewayV1(),
+		restClient:         c.restClient,
+	}
+}
+
+type gatewayV1ClientWithREST struct {
+	gatewayv1client.GatewayV1Interface
+	restClient rest.Interface
+}
+
+func (c *gatewayV1ClientWithREST) RESTClient() rest.Interface {
+	return c.restClient
+}
+
+func newTestGatewayRESTClient() rest.Interface {
+	cfg := &rest.Config{
+		Host: "https://127.0.0.1:6443",
+		ContentConfig: rest.ContentConfig{
+			GroupVersion:         &schema.GroupVersion{Group: gatewayv1.GroupName, Version: gatewayv1.GroupVersion.Version},
+			NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+		},
+	}
+	restClient, err := rest.RESTClientFor(cfg)
+	if err != nil {
+		panic(err)
+	}
+	return restClient
+}
+
+func newBuildTestKubernetesAPI(k8sClient *fake.Clientset, gwClient gatewayclient.Interface) *backend.KubernetesApi {
+	return &backend.KubernetesApi{
+		KubernetesInterface:  k8sClient,
+		CertmanagerInterface: &certClient.Clientset{},
+		GatewayInterface: &gatewayClientWithREST{
+			Interface:  gwClient,
+			restClient: newTestGatewayRESTClient(),
+		},
+	}
+}
 
 func prependAllowedGatewayWatchReactor(client *fake.Clientset) {
 	client.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
@@ -368,6 +420,19 @@ func Test_WithoutCache(t *testing.T) {
 	assertions.NotNil(kubernetes.Cache)
 }
 
+func Test_BuildSetsGatewaySystemDefaults(t *testing.T) {
+	assertions := require.New(t)
+	namespace := v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace1}}
+	clientset := fake.NewClientset(&namespace)
+	kube, err := NewKubernetesClientBuilder().
+		WithNamespace(testNamespace1).
+		WithClient(&backend.KubernetesApi{KubernetesInterface: clientset, CertmanagerInterface: &certClient.Clientset{}}).
+		Build()
+	assertions.NoError(err)
+	assertions.Equal(DefaultGatewaySystemNamespace, kube.GatewaySystem.Namespace)
+	assertions.Equal(DefaultGatewaySystemName, kube.GatewaySystem.Name)
+}
+
 func Test_BuildSkipsGatewayHTTPRouteWatchHandlersWithoutCache(t *testing.T) {
 	assertions := require.New(t)
 	k8sClient := fake.NewClientset()
@@ -395,19 +460,14 @@ func Test_BuildEnablesGatewayHTTPRouteWatchHandlers(t *testing.T) {
 		APIResources: []metav1.APIResource{{Kind: "HTTPRoute"}},
 	}}
 	gwClient := gatewayclientfake.NewSimpleClientset()
-	builder := NewKubernetesClientBuilder().
+	kube, err := NewKubernetesClientBuilder().
 		WithNamespace(testNamespace1).
-		WithClient(&backend.KubernetesApi{KubernetesInterface: k8sClient, CertmanagerInterface: &certClient.Clientset{}, GatewayInterface: gwClient}).
-		WithCache(cache.NewTestResourcesCache(cache.HttpRouteCache))
-	builder.applyDefaults()
-	handlers := NewSharedWatchEventHandlers(builder.watchExecutor, builder.watchClientTimeout,
-		k8sClient.CoreV1().RESTClient(),
-		builder.client.CertmanagerV1().RESTClient(),
-		k8sClient.NetworkingV1().RESTClient(),
-		k8sClient.ExtensionsV1beta1().RESTClient(),
-	)
-	assertions.NoError(builder.enrichWatchHandlersWithGatewayRoutes(handlers))
-	assertions.NotNil(handlers.HTTPRouteV1)
+		WithClient(newBuildTestKubernetesAPI(k8sClient, gwClient)).
+		WithWatchExecutor(newFakeWatchExecutor()).
+		WithCache(cache.NewTestResourcesCache(cache.HttpRouteCache)).
+		Build()
+	assertions.NoError(err)
+	assertions.NotNil(kube.WatchHandlers.HTTPRouteV1)
 }
 
 func Test_BuildEnablesGatewayGRPCRouteWatchHandlers(t *testing.T) {
@@ -420,19 +480,14 @@ func Test_BuildEnablesGatewayGRPCRouteWatchHandlers(t *testing.T) {
 		APIResources: []metav1.APIResource{{Kind: "GRPCRoute"}},
 	}}
 	gwClient := gatewayclientfake.NewSimpleClientset()
-	builder := NewKubernetesClientBuilder().
+	kube, err := NewKubernetesClientBuilder().
 		WithNamespace(testNamespace1).
-		WithClient(&backend.KubernetesApi{KubernetesInterface: k8sClient, CertmanagerInterface: &certClient.Clientset{}, GatewayInterface: gwClient}).
-		WithCache(cache.NewTestResourcesCache(cache.GrpcRouteCache))
-	builder.applyDefaults()
-	handlers := NewSharedWatchEventHandlers(builder.watchExecutor, builder.watchClientTimeout,
-		k8sClient.CoreV1().RESTClient(),
-		builder.client.CertmanagerV1().RESTClient(),
-		k8sClient.NetworkingV1().RESTClient(),
-		k8sClient.ExtensionsV1beta1().RESTClient(),
-	)
-	assertions.NoError(builder.enrichWatchHandlersWithGatewayRoutes(handlers))
-	assertions.NotNil(handlers.GRPCRouteV1)
+		WithClient(newBuildTestKubernetesAPI(k8sClient, gwClient)).
+		WithWatchExecutor(newFakeWatchExecutor()).
+		WithCache(cache.NewTestResourcesCache(cache.GrpcRouteCache)).
+		Build()
+	assertions.NoError(err)
+	assertions.NotNil(kube.WatchHandlers.GRPCRouteV1)
 }
 
 func Test_GetHttpRouteList_success(t *testing.T) {

--- a/service/internal/kubernetes/kubeService_test.go
+++ b/service/internal/kubernetes/kubeService_test.go
@@ -517,7 +517,7 @@ func Test_GetHttpRouteList_success(t *testing.T) {
 	list, err := kube.GetHttpRouteList(context.Background(), ns, filter.Meta{})
 	r.NoError(err)
 	r.Equal(2, len(list))
-	r.Equal(*entity.RouteFromHTTPRoute(hr1), list[0])
+	r.Equal(*entity.WrapHTTPRoute(hr1), list[0])
 }
 
 func Test_GetGrpcRouteList_success(t *testing.T) {

--- a/service/internal/kubernetes/kubeService_test.go
+++ b/service/internal/kubernetes/kubeService_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/smarty/assertions"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
+	authorizationv1 "k8s.io/api/authorization/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,9 +25,18 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayclientfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 )
+
+func prependAllowedGatewayWatchReactor(client *fake.Clientset) {
+	client.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		review := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		review.Status = authorizationv1.SubjectAccessReviewStatus{Allowed: true}
+		return true, review, nil
+	})
+}
 
 const (
 	testDeploymentName = "test-deployment"
@@ -358,40 +368,71 @@ func Test_WithoutCache(t *testing.T) {
 	assertions.NotNil(kubernetes.Cache)
 }
 
-func Test_BuildEnablesGatewayHTTPRouteWatchHandlers(t *testing.T) {
+func Test_BuildSkipsGatewayHTTPRouteWatchHandlersWithoutCache(t *testing.T) {
 	assertions := require.New(t)
 	k8sClient := fake.NewClientset()
-	// advertise gateway kinds in discovery
 	fakeDisc := k8sClient.Discovery().(*fakediscovery.FakeDiscovery)
 	fakeDisc.Resources = []*metav1.APIResourceList{{
 		GroupVersion: "gateway.networking.k8s.io/v1",
 		APIResources: []metav1.APIResource{{Kind: "HTTPRoute"}},
 	}}
-	// gateway client (fake)
 	gwClient := gatewayclientfake.NewSimpleClientset()
 	kube, err := NewKubernetesClientBuilder().
 		WithNamespace(testNamespace1).
 		WithClient(&backend.KubernetesApi{KubernetesInterface: k8sClient, CertmanagerInterface: &certClient.Clientset{}, GatewayInterface: gwClient}).
 		Build()
 	assertions.NoError(err)
-	assertions.NotNil(kube.WatchHandlers.HTTPRouteV1)
+	assertions.Nil(kube.WatchHandlers.HTTPRouteV1)
+}
+
+func Test_BuildEnablesGatewayHTTPRouteWatchHandlers(t *testing.T) {
+	assertions := require.New(t)
+	k8sClient := fake.NewClientset()
+	prependAllowedGatewayWatchReactor(k8sClient)
+	fakeDisc := k8sClient.Discovery().(*fakediscovery.FakeDiscovery)
+	fakeDisc.Resources = []*metav1.APIResourceList{{
+		GroupVersion: "gateway.networking.k8s.io/v1",
+		APIResources: []metav1.APIResource{{Kind: "HTTPRoute"}},
+	}}
+	gwClient := gatewayclientfake.NewSimpleClientset()
+	builder := NewKubernetesClientBuilder().
+		WithNamespace(testNamespace1).
+		WithClient(&backend.KubernetesApi{KubernetesInterface: k8sClient, CertmanagerInterface: &certClient.Clientset{}, GatewayInterface: gwClient}).
+		WithCache(cache.NewTestResourcesCache(cache.HttpRouteCache))
+	builder.applyDefaults()
+	handlers := NewSharedWatchEventHandlers(builder.watchExecutor, builder.watchClientTimeout,
+		k8sClient.CoreV1().RESTClient(),
+		builder.client.CertmanagerV1().RESTClient(),
+		k8sClient.NetworkingV1().RESTClient(),
+		k8sClient.ExtensionsV1beta1().RESTClient(),
+	)
+	assertions.NoError(builder.enrichWatchHandlersWithGatewayRoutes(handlers))
+	assertions.NotNil(handlers.HTTPRouteV1)
 }
 
 func Test_BuildEnablesGatewayGRPCRouteWatchHandlers(t *testing.T) {
 	assertions := require.New(t)
 	k8sClient := fake.NewClientset()
+	prependAllowedGatewayWatchReactor(k8sClient)
 	fakeDisc := k8sClient.Discovery().(*fakediscovery.FakeDiscovery)
 	fakeDisc.Resources = []*metav1.APIResourceList{{
 		GroupVersion: "gateway.networking.k8s.io/v1",
 		APIResources: []metav1.APIResource{{Kind: "GRPCRoute"}},
 	}}
 	gwClient := gatewayclientfake.NewSimpleClientset()
-	kube, err := NewKubernetesClientBuilder().
+	builder := NewKubernetesClientBuilder().
 		WithNamespace(testNamespace1).
 		WithClient(&backend.KubernetesApi{KubernetesInterface: k8sClient, CertmanagerInterface: &certClient.Clientset{}, GatewayInterface: gwClient}).
-		Build()
-	assertions.NoError(err)
-	assertions.NotNil(kube.WatchHandlers.GRPCRouteV1)
+		WithCache(cache.NewTestResourcesCache(cache.GrpcRouteCache))
+	builder.applyDefaults()
+	handlers := NewSharedWatchEventHandlers(builder.watchExecutor, builder.watchClientTimeout,
+		k8sClient.CoreV1().RESTClient(),
+		builder.client.CertmanagerV1().RESTClient(),
+		k8sClient.NetworkingV1().RESTClient(),
+		k8sClient.ExtensionsV1beta1().RESTClient(),
+	)
+	assertions.NoError(builder.enrichWatchHandlersWithGatewayRoutes(handlers))
+	assertions.NotNil(handlers.GRPCRouteV1)
 }
 
 func Test_GetHttpRouteList_success(t *testing.T) {

--- a/service/internal/kubernetes/kubeService_test.go
+++ b/service/internal/kubernetes/kubeService_test.go
@@ -420,6 +420,55 @@ func Test_WithoutCache(t *testing.T) {
 	assertions.NotNil(kubernetes.Cache)
 }
 
+func TestKubernetesClientBuilder_WithGatewaySystem(t *testing.T) {
+	assertions := require.New(t)
+	builder := NewKubernetesClientBuilder().
+		WithGatewaySystemType(GatewayApiDefault).
+		WithGatewaySystemNamespace("gw-ns").
+		WithGatewaySystemName("gw-name")
+	assertions.Equal(GatewayApiDefault, builder.gatewaySystem.Type)
+	assertions.Equal("gw-ns", builder.gatewaySystem.Namespace)
+	assertions.Equal("gw-name", builder.gatewaySystem.Name)
+}
+
+func Test_BuildSkipsEnrichWhenGatewayRouteCacheDisabled(t *testing.T) {
+	assertions := require.New(t)
+	namespace := v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace1}}
+	clientset := fake.NewClientset(&namespace)
+	kube, err := NewKubernetesClientBuilder().
+		WithNamespace(testNamespace1).
+		WithClient(&backend.KubernetesApi{KubernetesInterface: clientset, CertmanagerInterface: &certClient.Clientset{}}).
+		WithCache(cache.NewTestResourcesCache(cache.RouteCache)).
+		Build()
+	assertions.NoError(err)
+	assertions.Nil(kube.WatchHandlers.HTTPRouteV1)
+	assertions.Nil(kube.WatchHandlers.GRPCRouteV1)
+}
+
+func Test_BuildSkipsGatewayWatchWhenRBACDenied(t *testing.T) {
+	assertions := require.New(t)
+	k8sClient := fake.NewClientset()
+	k8sClient.PrependReactor("create", "selfsubjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		review := action.(k8stesting.CreateAction).GetObject().(*authorizationv1.SelfSubjectAccessReview)
+		review.Status = authorizationv1.SubjectAccessReviewStatus{Allowed: false}
+		return true, review, nil
+	})
+	fakeDisc := k8sClient.Discovery().(*fakediscovery.FakeDiscovery)
+	fakeDisc.Resources = []*metav1.APIResourceList{{
+		GroupVersion: "gateway.networking.k8s.io/v1",
+		APIResources: []metav1.APIResource{{Kind: "HTTPRoute"}},
+	}}
+	gwClient := gatewayclientfake.NewSimpleClientset()
+	kube, err := NewKubernetesClientBuilder().
+		WithNamespace(testNamespace1).
+		WithClient(newBuildTestKubernetesAPI(k8sClient, gwClient)).
+		WithWatchExecutor(newFakeWatchExecutor()).
+		WithCache(cache.NewTestResourcesCache(cache.HttpRouteCache)).
+		Build()
+	assertions.NoError(err)
+	assertions.Nil(kube.WatchHandlers.HTTPRouteV1)
+}
+
 func Test_BuildSetsGatewaySystemDefaults(t *testing.T) {
 	assertions := require.New(t)
 	namespace := v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace1}}

--- a/service/internal/kubernetes/kubeWatchServiceShared.go
+++ b/service/internal/kubernetes/kubeWatchServiceShared.go
@@ -140,7 +140,7 @@ func NewSharedWatchEventHandlers(executor pmWatch.Executor,
 func (h *SharedWatchHandlers) WithHTTPRouteV1(executor pmWatch.Executor, clientTimeout time.Duration, gatewayV1 rest.Interface) {
 	h.HTTPRouteV1 = NewSharedWatchEventHandler(types.HTTPRoutes, clientTimeout, func(namespace string, kind types.PaasResourceType) *sharedNamespaceWatchHandler[*gatewayv1.HTTPRoute, entity.HttpRoute] {
 		return newSharedNamespaceWatchHandler(namespace, kind, clientTimeout, func(namespace string, kind types.PaasResourceType) *RestWatchEventHandler[*gatewayv1.HTTPRoute, entity.HttpRoute] {
-			return NewRestWatchHandler(namespace, kind, gatewayV1, executor, entity.RouteFromHTTPRoute)
+			return NewRestWatchHandler(namespace, kind, gatewayV1, executor, entity.WrapHTTPRoute)
 		})
 	})
 }

--- a/service/internal/kubernetes/kubeWatchService_test.go
+++ b/service/internal/kubernetes/kubeWatchService_test.go
@@ -224,7 +224,7 @@ func TestWatchGatewayHTTPRoutesAddedEvent(t *testing.T) {
 		for watchEvent := range watchHandler.Channel {
 			logger.Info("Get event %s", watchEvent.Type)
 			r.Equal("ADDED", watchEvent.Type)
-			expected := entity.RouteFromHTTPRoute(route)
+			expected := entity.WrapHTTPRoute(route)
 			r.True(So(watchEvent.Object, ShouldResemble, expected))
 			break
 		}
@@ -312,7 +312,7 @@ func TestWatchGatewayHTTPRoutesDeletedEvent(t *testing.T) {
 		for watchEvent := range watchHandler.Channel {
 			logger.Info("Get event %s", watchEvent.Type)
 			r.Equal("DELETED", watchEvent.Type)
-			expected := entity.RouteFromHTTPRoute(route)
+			expected := entity.WrapHTTPRoute(route)
 			r.True(So(watchEvent.Object, ShouldResemble, expected))
 			break
 		}

--- a/service/internal/kubernetes/kubeWatchService_test.go
+++ b/service/internal/kubernetes/kubeWatchService_test.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 )
 
@@ -43,6 +44,9 @@ func newFakeWatchExecutor() *fakeWatchExecutor {
 func (e *fakeWatchExecutor) CreateWatchRequest(restClient rest.Interface, resource types.PaasResourceType, options *v1.ListOptions) *rest.Request {
 	e.requestedResources = resource.String()
 	e.requestedOptions = options
+	if restClient != nil {
+		return restClient.Get().Resource(resource.String()).VersionedParams(options, scheme.ParameterCodec)
+	}
 	return &rest.Request{}
 }
 

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -42,8 +42,8 @@ func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, na
 		return nil, kube.GatewaySystem.RouteCreationNotAllowedError()
 	}
 
-	useGatewayAPI := kube.GatewaySystem.ShouldUseGatewayAPI()
-	useLegacyIngress := kube.GatewaySystem.ShouldCreateLegacyIngress()
+	useGatewayAPI := kube.GatewaySystem.IsGatewayAPIEnabled()
+	useLegacyIngress := kube.GatewaySystem.IsIngressEnabled()
 
 	var result *entity.Route
 	var err error
@@ -104,8 +104,8 @@ func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.R
 		return nil, kube.GatewaySystem.RouteUpdateNotAllowedError()
 	}
 
-	useGatewayAPI := kube.GatewaySystem.ShouldUseGatewayAPI()
-	useLegacyIngress := kube.GatewaySystem.ShouldCreateLegacyIngress()
+	useGatewayAPI := kube.GatewaySystem.IsGatewayAPIEnabled()
+	useLegacyIngress := kube.GatewaySystem.IsIngressEnabled()
 
 	var result *entity.Route
 	var httpRouteExists bool
@@ -233,38 +233,42 @@ func (kube *Kubernetes) GetRoute(ctx context.Context, resourceName string, names
 	}
 }
 
-func (kube *Kubernetes) DeleteRoute(ctx context.Context, routeName string, namespace string) error {
-	var firstErr error
+func (kube *Kubernetes) DeleteRoute(ctx context.Context, routeName, namespace string) error {
+	var (
+		httpRouteErr       error
+		httpRouteAttempted bool
+	)
 
-	if kube.GatewaySystem.ShouldUseGatewayAPI() {
-		if err := kube.deleteRouteHTTPRoute(ctx, routeName, namespace); err != nil {
-			firstErr = err
+	if kube.GatewaySystem.IsGatewayAPIEnabled() {
+		httpRouteAttempted = true
+		httpRouteErr = kube.deleteRouteHTTPRoute(ctx, routeName, namespace)
+		if httpRouteErr != nil && !paasErrors.IsNotFound(httpRouteErr) {
+			return httpRouteErr
 		}
 	}
 
-	if kube.GatewaySystem.ShouldCreateLegacyIngress() {
-		if err := kube.deleteRouteLegacyIngress(ctx, routeName, namespace); err != nil && firstErr == nil {
-			firstErr = err
+	if kube.GatewaySystem.IsIngressEnabled() {
+		ingressErr := kube.deleteRouteLegacyIngress(ctx, routeName, namespace)
+		if ingressErr != nil && paasErrors.IsNotFound(ingressErr) && httpRouteAttempted && httpRouteErr == nil {
+			return nil
 		}
+		return ingressErr
 	}
 
-	return firstErr
+	return httpRouteErr
 }
 
 func (kube *Kubernetes) deleteRouteHTTPRoute(ctx context.Context, routeName, namespace string) error {
 	err := kube.getGatewayV1Client().HTTPRoutes(namespace).Delete(ctx, routeName, v1.DeleteOptions{})
-	if err == nil {
-		logger.InfoC(ctx, "HTTPRoute deleted: %s", routeName)
-		if kube.Cache.HTTPRoute != nil {
-			kube.Cache.HTTPRoute.Delete(ctx, namespace, routeName)
-		}
-		return nil
+	if err != nil {
+		logger.ErrorC(ctx, "Error while deleting HTTPRoute=%s from kubernetes: %+v", routeName, err)
+		return err
 	}
-	if paasErrors.IsNotFound(err) {
-		return nil
+	logger.InfoC(ctx, "HTTPRoute deleted: %s", routeName)
+	if kube.Cache.HTTPRoute != nil {
+		kube.Cache.HTTPRoute.Delete(ctx, namespace, routeName)
 	}
-	logger.ErrorC(ctx, "Error while deleting HTTPRoute=%s from kubernetes: %+v", routeName, err)
-	return err
+	return nil
 }
 
 func (kube *Kubernetes) deleteRouteLegacyIngress(ctx context.Context, routeName, namespace string) error {
@@ -274,18 +278,15 @@ func (kube *Kubernetes) deleteRouteLegacyIngress(ctx context.Context, routeName,
 	} else {
 		err = kube.getExtensionsV1Client().Ingresses(namespace).Delete(ctx, routeName, v1.DeleteOptions{})
 	}
-	if err == nil {
-		logger.InfoC(ctx, "Ingress deleted: %s", routeName)
-		if kube.Cache.Ingresses != nil {
-			kube.Cache.Ingresses.Delete(ctx, namespace, routeName)
-		}
-		return nil
+	if err != nil {
+		logger.ErrorC(ctx, "Error while deleting ingress=%s from kubernetes: %+v", routeName, err)
+		return err
 	}
-	if paasErrors.IsNotFound(err) {
-		return nil
+	logger.InfoC(ctx, "Ingress deleted: %s", routeName)
+	if kube.Cache.Ingresses != nil {
+		kube.Cache.Ingresses.Delete(ctx, namespace, routeName)
 	}
-	logger.ErrorC(ctx, "Error while deleting ingress=%s from kubernetes: %+v", routeName, err)
-	return err
+	return nil
 }
 
 func (kube *Kubernetes) GetRouteList(ctx context.Context, namespace string, filter filter.Meta) ([]entity.Route, error) {

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -125,9 +125,9 @@ func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.R
 			}
 			logger.InfoC(ctx, "HTTPRoute updated: %s", route.Name)
 
-			routeFromHTTPRoute := entity.RouteFromHTTPRouteGatewayV1(updatedHTTPRoute)
+			routeFromHTTPRoute := entity.RouteFromHTTPRoute(updatedHTTPRoute)
 			if kube.Cache.HTTPRoute != nil && routeFromHTTPRoute != nil {
-				httpRouteEntity := entity.RouteFromHTTPRoute(updatedHTTPRoute)
+				httpRouteEntity := entity.WrapHTTPRoute(updatedHTTPRoute)
 				_, err := kube.Cache.HTTPRoute.Set(ctx, *httpRouteEntity)
 				if err != nil {
 					return nil, fmt.Errorf("failed to place HTTPRoute into cache: %w", err)
@@ -308,7 +308,7 @@ func (kube *Kubernetes) GetHttpRouteList(ctx context.Context, namespace string, 
 	return ListWrapper(ctx, filter, kube.getGatewayV1Client().HTTPRoutes(namespace).List, kube.Cache.HTTPRoute,
 		func(listObj *gatewayv1.HTTPRouteList) (result []entity.HttpRoute) {
 			for _, item := range listObj.Items {
-				route := entity.RouteFromHTTPRoute(&item)
+				route := entity.WrapHTTPRoute(&item)
 				if route != nil {
 					result = append(result, *route)
 				}
@@ -445,9 +445,9 @@ func (kube *Kubernetes) createHTTPRoute(ctx context.Context, route *entity.Route
 		return nil, err
 	}
 
-	routeFromHTTPRoute := entity.RouteFromHTTPRouteGatewayV1(createdHTTPRoute)
+	routeFromHTTPRoute := entity.RouteFromHTTPRoute(createdHTTPRoute)
 	if kube.Cache.HTTPRoute != nil && routeFromHTTPRoute != nil {
-		httpRouteEntity := entity.RouteFromHTTPRoute(createdHTTPRoute)
+		httpRouteEntity := entity.WrapHTTPRoute(createdHTTPRoute)
 		_, err := kube.Cache.HTTPRoute.Set(ctx, *httpRouteEntity)
 		if err != nil {
 			return nil, fmt.Errorf("failed to place HTTPRoute into cache: %w", err)

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -16,6 +16,7 @@ import (
 )
 
 var BG2IngressClassName = "bg.mesh.netcracker.com"
+var IgnoreApiConverterAnnotation = "gateway-api-converter.netcracker.com/ignore"
 
 func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
 	useGatewayAPI := kube.shouldUseGatewayAPI()
@@ -48,7 +49,7 @@ func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, na
 			if ingress.Annotations == nil {
 				ingress.Annotations = make(map[string]string)
 			}
-			ingress.Annotations["gateway-api-converter.netcracker.com/ignore"] = "true"
+			ingress.Annotations[IgnoreApiConverterAnnotation] = "true"
 		}
 
 		createdIngress, e := kube.getNetworkingV1Client().Ingresses(namespace).Create(ctx, ingress, v1.CreateOptions{})
@@ -73,7 +74,7 @@ func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, na
 			if ingress.Annotations == nil {
 				ingress.Annotations = make(map[string]string)
 			}
-			ingress.Annotations["gateway-api-converter.netcracker.com/ignore"] = "true"
+			ingress.Annotations[IgnoreApiConverterAnnotation] = "true"
 		}
 
 		createdIngress, e := kube.getExtensionsV1Client().Ingresses(namespace).Create(ctx, ingress, v1.CreateOptions{})
@@ -150,7 +151,7 @@ func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.R
 					if ingressToUpdate.Annotations == nil {
 						ingressToUpdate.Annotations = make(map[string]string)
 					}
-					ingressToUpdate.Annotations["gateway-api-converter.netcracker.com/ignore"] = "true"
+					ingressToUpdate.Annotations[IgnoreApiConverterAnnotation] = "true"
 				}
 
 				updatedIngress, err := kube.getNetworkingV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
@@ -186,7 +187,7 @@ func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.R
 					if ingressToUpdate.Annotations == nil {
 						ingressToUpdate.Annotations = make(map[string]string)
 					}
-					ingressToUpdate.Annotations["gateway-api-converter.netcracker.com/ignore"] = "true"
+					ingressToUpdate.Annotations[IgnoreApiConverterAnnotation] = "true"
 				}
 
 				updatedIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
@@ -232,46 +233,58 @@ func (kube *Kubernetes) GetRoute(ctx context.Context, resourceName string, names
 }
 
 func (kube *Kubernetes) DeleteRoute(ctx context.Context, routeName string, namespace string) error {
-	useGatewayAPI := kube.shouldUseGatewayAPI()
-	useLegacyIngress := kube.shouldCreateLegacyIngress()
-
 	var firstErr error
 
-	if useGatewayAPI {
-		err := kube.getGatewayV1Client().HTTPRoutes(namespace).Delete(ctx, routeName, v1.DeleteOptions{})
-		if err != nil && !paasErrors.IsNotFound(err) {
-			logger.ErrorC(ctx, "Error while deleting HTTPRoute=%s from kubernetes: %+v", routeName, err)
+	if kube.shouldUseGatewayAPI() {
+		if err := kube.deleteRouteHTTPRoute(ctx, routeName, namespace); err != nil {
 			firstErr = err
-		} else if err == nil {
-			logger.InfoC(ctx, "HTTPRoute deleted: %s", routeName)
-			if kube.Cache.HTTPRoute != nil {
-				kube.Cache.HTTPRoute.Delete(ctx, namespace, routeName)
-			}
 		}
 	}
 
-	if useLegacyIngress {
-		var err error
-		if kube.UseNetworkingV1Ingress {
-			err = kube.getNetworkingV1Client().Ingresses(namespace).Delete(ctx, routeName, v1.DeleteOptions{})
-		} else {
-			err = kube.getExtensionsV1Client().Ingresses(namespace).Delete(ctx, routeName, v1.DeleteOptions{})
-		}
-
-		if err != nil && !paasErrors.IsNotFound(err) {
-			logger.ErrorC(ctx, "Error while deleting ingress=%s from kubernetes: %+v", routeName, err)
-			if firstErr == nil {
-				firstErr = err
-			}
-		} else if err == nil {
-			logger.InfoC(ctx, "Ingress deleted: %s", routeName)
-			if kube.Cache.Ingresses != nil {
-				kube.Cache.Ingresses.Delete(ctx, namespace, routeName)
-			}
+	if kube.shouldCreateLegacyIngress() {
+		if err := kube.deleteRouteLegacyIngress(ctx, routeName, namespace); err != nil && firstErr == nil {
+			firstErr = err
 		}
 	}
 
 	return firstErr
+}
+
+func (kube *Kubernetes) deleteRouteHTTPRoute(ctx context.Context, routeName, namespace string) error {
+	err := kube.getGatewayV1Client().HTTPRoutes(namespace).Delete(ctx, routeName, v1.DeleteOptions{})
+	if err == nil {
+		logger.InfoC(ctx, "HTTPRoute deleted: %s", routeName)
+		if kube.Cache.HTTPRoute != nil {
+			kube.Cache.HTTPRoute.Delete(ctx, namespace, routeName)
+		}
+		return nil
+	}
+	if paasErrors.IsNotFound(err) {
+		return nil
+	}
+	logger.ErrorC(ctx, "Error while deleting HTTPRoute=%s from kubernetes: %+v", routeName, err)
+	return err
+}
+
+func (kube *Kubernetes) deleteRouteLegacyIngress(ctx context.Context, routeName, namespace string) error {
+	var err error
+	if kube.UseNetworkingV1Ingress {
+		err = kube.getNetworkingV1Client().Ingresses(namespace).Delete(ctx, routeName, v1.DeleteOptions{})
+	} else {
+		err = kube.getExtensionsV1Client().Ingresses(namespace).Delete(ctx, routeName, v1.DeleteOptions{})
+	}
+	if err == nil {
+		logger.InfoC(ctx, "Ingress deleted: %s", routeName)
+		if kube.Cache.Ingresses != nil {
+			kube.Cache.Ingresses.Delete(ctx, namespace, routeName)
+		}
+		return nil
+	}
+	if paasErrors.IsNotFound(err) {
+		return nil
+	}
+	logger.ErrorC(ctx, "Error while deleting ingress=%s from kubernetes: %+v", routeName, err)
+	return err
 }
 
 func (kube *Kubernetes) GetRouteList(ctx context.Context, namespace string, filter filter.Meta) ([]entity.Route, error) {

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -38,12 +38,12 @@ const (
 )
 
 func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
+	if !kube.GatewaySystem.IsRouteCreationAllowed() {
+		return nil, kube.GatewaySystem.RouteCreationNotAllowedError()
+	}
+
 	useGatewayAPI := kube.GatewaySystem.ShouldUseGatewayAPI()
 	useLegacyIngress := kube.GatewaySystem.ShouldCreateLegacyIngress()
-
-	if !useGatewayAPI && !useLegacyIngress {
-		return nil, fmt.Errorf("GATEWAY_SYSTEM_TYPE=%s does not allow any Route creation", kube.GatewaySystem.Type)
-	}
 
 	var result *entity.Route
 	var err error
@@ -62,14 +62,7 @@ func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, na
 
 	if kube.UseNetworkingV1Ingress {
 		ingress := route.ToIngressNetworkingV1()
-		kube.modifyIngressClassForBG2(ingress)
-
-		if kube.GatewaySystem.ShouldIgnoreIngressForConverter() {
-			if ingress.Annotations == nil {
-				ingress.Annotations = make(map[string]string)
-			}
-			ingress.Annotations[IgnoreApiConverterAnnotation] = "true"
-		}
+		kube.configureIngress(ingress)
 
 		createdIngress, e := kube.getNetworkingV1Client().Ingresses(namespace).Create(ctx, ingress, v1.CreateOptions{})
 		if e != nil {
@@ -87,14 +80,7 @@ func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, na
 		return ingressNetworkingV1, nil
 	} else {
 		ingress := route.ToIngress()
-		kube.modifyIngressClassForBG2(ingress)
-
-		if kube.GatewaySystem.ShouldIgnoreIngressForConverter() {
-			if ingress.Annotations == nil {
-				ingress.Annotations = make(map[string]string)
-			}
-			ingress.Annotations[IgnoreApiConverterAnnotation] = "true"
-		}
+		kube.configureIngress(ingress)
 
 		createdIngress, e := kube.getExtensionsV1Client().Ingresses(namespace).Create(ctx, ingress, v1.CreateOptions{})
 		if e != nil {
@@ -114,12 +100,12 @@ func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, na
 }
 
 func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
+	if !kube.GatewaySystem.IsRouteCreationAllowed() {
+		return nil, kube.GatewaySystem.RouteUpdateNotAllowedError()
+	}
+
 	useGatewayAPI := kube.GatewaySystem.ShouldUseGatewayAPI()
 	useLegacyIngress := kube.GatewaySystem.ShouldCreateLegacyIngress()
-
-	if !useGatewayAPI && !useLegacyIngress {
-		return nil, fmt.Errorf("GATEWAY_SYSTEM_TYPE=%s does not allow any Route update", kube.GatewaySystem.Type)
-	}
 
 	var result *entity.Route
 	var httpRouteExists bool
@@ -164,14 +150,7 @@ func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.R
 				if className := ingressToUpdate.Spec.IngressClassName; className == nil || *className == "" {
 					ingressToUpdate.Spec.IngressClassName = originalIngress.Spec.IngressClassName
 				}
-				kube.modifyIngressClassForBG2(ingressToUpdate)
-
-				if kube.GatewaySystem.ShouldIgnoreIngressForConverter() {
-					if ingressToUpdate.Annotations == nil {
-						ingressToUpdate.Annotations = make(map[string]string)
-					}
-					ingressToUpdate.Annotations[IgnoreApiConverterAnnotation] = "true"
-				}
+				kube.configureIngress(ingressToUpdate)
 
 				updatedIngress, err := kube.getNetworkingV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
 				if err != nil {
@@ -200,14 +179,7 @@ func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.R
 				ingressExists = true
 				ingressToUpdate := route.ToIngress()
 				ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
-				kube.modifyIngressClassForBG2(ingressToUpdate)
-
-				if kube.GatewaySystem.ShouldIgnoreIngressForConverter() {
-					if ingressToUpdate.Annotations == nil {
-						ingressToUpdate.Annotations = make(map[string]string)
-					}
-					ingressToUpdate.Annotations[IgnoreApiConverterAnnotation] = "true"
-				}
+				kube.configureIngress(ingressToUpdate)
 
 				updatedIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
 				if err != nil {
@@ -382,6 +354,29 @@ func (kube *Kubernetes) WatchGatewayGRPCRoutes(ctx context.Context, namespace st
 		return nil, fmt.Errorf("k8s GRPCRoute is not supported")
 	}
 	return kube.WatchHandlers.GRPCRouteV1.Watch(ctx, namespace, metaFilter)
+}
+
+func (kube *Kubernetes) configureIngress(ingress any) {
+	kube.modifyIngressClassForBG2(ingress)
+	if kube.GatewaySystem.IsBothGatewaySystemsEnabled() {
+		kube.ignoreApiConverter(ingress)
+	}
+}
+
+func applyIgnoreApiConverterAnnotation(meta *v1.ObjectMeta) {
+	if meta.Annotations == nil {
+		meta.Annotations = make(map[string]string)
+	}
+	meta.Annotations[IgnoreApiConverterAnnotation] = "true"
+}
+
+func (kube *Kubernetes) ignoreApiConverter(ingress any) {
+	switch i := ingress.(type) {
+	case *networkingV1.Ingress:
+		applyIgnoreApiConverterAnnotation(&i.ObjectMeta)
+	case *v1beta1.Ingress:
+		applyIgnoreApiConverterAnnotation(&i.ObjectMeta)
+	}
 }
 
 func (kube *Kubernetes) modifyIngressClassForBG2(ingress any) {

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/netcracker/qubership-core-lib-go-paas-mediation-client/v8/entity"
 	"github.com/netcracker/qubership-core-lib-go-paas-mediation-client/v8/filter"
@@ -12,16 +11,16 @@ import (
 	networkingV1 "k8s.io/api/networking/v1"
 	paasErrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 var BG2IngressClassName = "bg.mesh.netcracker.com"
-var IgnoreApiConverterAnnotation = "gateway-api-converter.netcracker.com/ignore"
+
+const IgnoreApiConverterAnnotation = "gateway-api-converter.netcracker.com/ignore"
 
 const (
-	LegacyIngress     = "legacy-ingress"
-	GatewayApiDefault = "gateway-api-default"
-
 	AnnotationBackendProtocol   = "nginx.ingress.kubernetes.io/backend-protocol"
 	AnnotationSecureBackends    = "nginx.ingress.kubernetes.io/secure-backends"
 	AnnotationAuthType          = "nginx.ingress.kubernetes.io/auth-type"
@@ -39,20 +38,17 @@ const (
 )
 
 func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
-	useGatewayAPI := kube.shouldUseGatewayAPI()
-	useLegacyIngress := kube.shouldCreateLegacyIngress()
+	useGatewayAPI := kube.GatewaySystem.ShouldUseGatewayAPI()
+	useLegacyIngress := kube.GatewaySystem.ShouldCreateLegacyIngress()
 
 	if !useGatewayAPI && !useLegacyIngress {
-		return nil, fmt.Errorf("GATEWAY_SYSTEM_TYPE=%s does not allow any Route creation", kube.GatewaySystemType)
+		return nil, fmt.Errorf("GATEWAY_SYSTEM_TYPE=%s does not allow any Route creation", kube.GatewaySystem.Type)
 	}
 
 	var result *entity.Route
 	var err error
 
 	if useGatewayAPI {
-		if err = kube.validateAnnotationsForGatewayAPI(route.Metadata.Annotations); err != nil {
-			return nil, err
-		}
 		result, err = kube.createHTTPRoute(ctx, route, namespace)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create HTTPRoute: %w", err)
@@ -68,7 +64,7 @@ func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, na
 		ingress := route.ToIngressNetworkingV1()
 		kube.modifyIngressClassForBG2(ingress)
 
-		if kube.shouldIgnoreIngressForConverter() {
+		if kube.GatewaySystem.ShouldIgnoreIngressForConverter() {
 			if ingress.Annotations == nil {
 				ingress.Annotations = make(map[string]string)
 			}
@@ -93,7 +89,7 @@ func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, na
 		ingress := route.ToIngress()
 		kube.modifyIngressClassForBG2(ingress)
 
-		if kube.shouldIgnoreIngressForConverter() {
+		if kube.GatewaySystem.ShouldIgnoreIngressForConverter() {
 			if ingress.Annotations == nil {
 				ingress.Annotations = make(map[string]string)
 			}
@@ -118,11 +114,11 @@ func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, na
 }
 
 func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
-	useGatewayAPI := kube.shouldUseGatewayAPI()
-	useLegacyIngress := kube.shouldCreateLegacyIngress()
+	useGatewayAPI := kube.GatewaySystem.ShouldUseGatewayAPI()
+	useLegacyIngress := kube.GatewaySystem.ShouldCreateLegacyIngress()
 
 	if !useGatewayAPI && !useLegacyIngress {
-		return nil, fmt.Errorf("GATEWAY_SYSTEM_TYPE=%s does not allow any Route update", kube.GatewaySystemType)
+		return nil, fmt.Errorf("GATEWAY_SYSTEM_TYPE=%s does not allow any Route update", kube.GatewaySystem.Type)
 	}
 
 	var result *entity.Route
@@ -133,7 +129,7 @@ func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.R
 		originalHTTPRoute, err := kube.getGatewayV1Client().HTTPRoutes(namespace).Get(ctx, route.Name, v1.GetOptions{})
 		if err == nil {
 			httpRouteExists = true
-			httpRouteToUpdate := route.ToHTTPRoute(kube.GatewaySystemNamespace, kube.GatewaySystemName)
+			httpRouteToUpdate := route.ToHTTPRoute(kube.GatewaySystem.Namespace, kube.GatewaySystem.Name)
 			httpRouteToUpdate.ResourceVersion = originalHTTPRoute.ResourceVersion
 
 			updatedHTTPRoute, err := kube.getGatewayV1Client().HTTPRoutes(namespace).Update(ctx, httpRouteToUpdate, v1.UpdateOptions{})
@@ -170,7 +166,7 @@ func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.R
 				}
 				kube.modifyIngressClassForBG2(ingressToUpdate)
 
-				if kube.shouldIgnoreIngressForConverter() {
+				if kube.GatewaySystem.ShouldIgnoreIngressForConverter() {
 					if ingressToUpdate.Annotations == nil {
 						ingressToUpdate.Annotations = make(map[string]string)
 					}
@@ -206,7 +202,7 @@ func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.R
 				ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
 				kube.modifyIngressClassForBG2(ingressToUpdate)
 
-				if kube.shouldIgnoreIngressForConverter() {
+				if kube.GatewaySystem.ShouldIgnoreIngressForConverter() {
 					if ingressToUpdate.Annotations == nil {
 						ingressToUpdate.Annotations = make(map[string]string)
 					}
@@ -258,13 +254,13 @@ func (kube *Kubernetes) GetRoute(ctx context.Context, resourceName string, names
 func (kube *Kubernetes) DeleteRoute(ctx context.Context, routeName string, namespace string) error {
 	var firstErr error
 
-	if kube.shouldUseGatewayAPI() {
+	if kube.GatewaySystem.ShouldUseGatewayAPI() {
 		if err := kube.deleteRouteHTTPRoute(ctx, routeName, namespace); err != nil {
 			firstErr = err
 		}
 	}
 
-	if kube.shouldCreateLegacyIngress() {
+	if kube.GatewaySystem.ShouldCreateLegacyIngress() {
 		if err := kube.deleteRouteLegacyIngress(ctx, routeName, namespace); err != nil && firstErr == nil {
 			firstErr = err
 		}
@@ -406,28 +402,6 @@ func (kube *Kubernetes) modifyIngressClassForBG2(ingress any) {
 	}
 }
 
-func (kube *Kubernetes) shouldUseGatewayAPI() bool {
-	if kube.GatewaySystemType == "" {
-		return false
-	}
-	return strings.Contains(kube.GatewaySystemType, GatewayApiDefault)
-}
-
-func (kube *Kubernetes) shouldCreateLegacyIngress() bool {
-	if kube.GatewaySystemType == "" {
-		return true
-	}
-	return strings.Contains(kube.GatewaySystemType, LegacyIngress)
-}
-
-func (kube *Kubernetes) shouldIgnoreIngressForConverter() bool {
-	if kube.GatewaySystemType == "" {
-		return false
-	}
-	return strings.Contains(kube.GatewaySystemType, LegacyIngress) &&
-		strings.Contains(kube.GatewaySystemType, GatewayApiDefault)
-}
-
 func (kube *Kubernetes) validateAnnotationsForGatewayAPI(annotations map[string]string) error {
 	criticalAnnotations := map[string]string{
 		AnnotationBackendProtocol:   BackendTlsOrTrafficWarning,
@@ -440,19 +414,34 @@ func (kube *Kubernetes) validateAnnotationsForGatewayAPI(annotations map[string]
 		AnnotationProxyRedirectTo:   EnvoyExtensionWarning,
 	}
 
+	var fieldErrors field.ErrorList
 	for key, message := range criticalAnnotations {
-		if val, exists := annotations[key]; exists && val != "" {
-			return fmt.Errorf("annotation '%s' is not supported for HTTPRoute creation: %s", key, message)
+		if val := annotations[key]; val != "" {
+			fieldErrors = append(fieldErrors, field.Invalid(
+				field.NewPath("metadata", "annotations").Key(key),
+				val,
+				fmt.Sprintf("not supported for HTTPRoute creation: %s", message),
+			))
 		}
 	}
-
-	return nil
+	if len(fieldErrors) == 0 {
+		return nil
+	}
+	return paasErrors.NewInvalid(
+		schema.GroupKind{Group: gatewayv1.GroupName, Kind: "HTTPRoute"},
+		"",
+		fieldErrors,
+	)
 }
 
 func (kube *Kubernetes) createHTTPRoute(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
+	if err := kube.validateAnnotationsForGatewayAPI(route.Metadata.Annotations); err != nil {
+		return nil, err
+	}
+
 	httpRoute := route.ToHTTPRoute(
-		kube.GatewaySystemNamespace,
-		kube.GatewaySystemName,
+		kube.GatewaySystem.Namespace,
+		kube.GatewaySystem.Name,
 	)
 
 	createdHTTPRoute, err := kube.getGatewayV1Client().HTTPRoutes(namespace).Create(ctx, httpRoute, v1.CreateOptions{})

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -113,94 +113,93 @@ func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.R
 
 	if useGatewayAPI {
 		originalHTTPRoute, err := kube.getGatewayV1Client().HTTPRoutes(namespace).Get(ctx, route.Name, v1.GetOptions{})
-		if err == nil {
-			httpRouteExists = true
-			httpRouteToUpdate := route.ToHTTPRoute(kube.GatewaySystem.Namespace, kube.GatewaySystem.Name)
-			httpRouteToUpdate.ResourceVersion = originalHTTPRoute.ResourceVersion
-
-			updatedHTTPRoute, err := kube.getGatewayV1Client().HTTPRoutes(namespace).Update(ctx, httpRouteToUpdate, v1.UpdateOptions{})
-			if err != nil {
-				logger.ErrorC(ctx, "Error to update HTTPRoute: %+v", err)
+		if err != nil {
+			if !paasErrors.IsNotFound(err) {
+				logger.ErrorC(ctx, "Error to get HTTPRoute before update: %+v", err)
 				return nil, err
 			}
-			logger.InfoC(ctx, "HTTPRoute updated: %s", route.Name)
-
-			routeFromHTTPRoute := entity.RouteFromHTTPRoute(updatedHTTPRoute)
-			if kube.Cache.HTTPRoute != nil && routeFromHTTPRoute != nil {
-				httpRouteEntity := entity.WrapHTTPRoute(updatedHTTPRoute)
-				_, err := kube.Cache.HTTPRoute.Set(ctx, *httpRouteEntity)
-				if err != nil {
-					return nil, fmt.Errorf("failed to place HTTPRoute into cache: %w", err)
-				}
-			}
-			result = routeFromHTTPRoute
-		} else if !paasErrors.IsNotFound(err) {
-			logger.ErrorC(ctx, "Error to get HTTPRoute before update: %+v", err)
+		}
+		httpRouteExists = true
+		httpRouteToUpdate := route.ToHTTPRoute(kube.GatewaySystem.Namespace, kube.GatewaySystem.Name)
+		httpRouteToUpdate.ResourceVersion = originalHTTPRoute.ResourceVersion
+		updatedHTTPRoute, err := kube.getGatewayV1Client().HTTPRoutes(namespace).Update(ctx, httpRouteToUpdate, v1.UpdateOptions{})
+		if err != nil {
+			logger.ErrorC(ctx, "Error to update HTTPRoute: %+v", err)
 			return nil, err
 		}
+		logger.InfoC(ctx, "HTTPRoute updated: %s", route.Name)
+		routeFromHTTPRoute := entity.RouteFromHTTPRoute(updatedHTTPRoute)
+		if kube.Cache.HTTPRoute != nil && routeFromHTTPRoute != nil {
+			httpRouteEntity := entity.WrapHTTPRoute(updatedHTTPRoute)
+			_, err := kube.Cache.HTTPRoute.Set(ctx, *httpRouteEntity)
+			if err != nil {
+				return nil, fmt.Errorf("failed to place HTTPRoute into cache: %w", err)
+			}
+		}
+		result = routeFromHTTPRoute
+
 	}
 
 	if useLegacyIngress {
 		if kube.UseNetworkingV1Ingress {
 			originalIngress, err := kube.getNetworkingV1Client().Ingresses(namespace).Get(ctx, route.Name, v1.GetOptions{})
-			if err == nil {
-				ingressExists = true
-				ingressToUpdate := route.ToIngressNetworkingV1()
-				ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
-				if className := ingressToUpdate.Spec.IngressClassName; className == nil || *className == "" {
-					ingressToUpdate.Spec.IngressClassName = originalIngress.Spec.IngressClassName
-				}
-				kube.configureIngress(ingressToUpdate)
-
-				updatedIngress, err := kube.getNetworkingV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
-				if err != nil {
-					logger.ErrorC(ctx, "Error to update ingress: %+v", err)
+			if err != nil {
+				if !paasErrors.IsNotFound(err) {
+					logger.ErrorC(ctx, "Error to get ingress before update: %+v", err)
 					return nil, err
 				}
-				logger.InfoC(ctx, "Ingress updated: %s", route.Name)
+			}
 
-				ingressNetworkingV1 := entity.RouteFromIngressNetworkingV1(updatedIngress)
-				if kube.Cache.Ingresses != nil && ingressNetworkingV1 != nil {
-					_, err := kube.Cache.Ingresses.Set(ctx, *ingressNetworkingV1)
-					if err != nil {
-						return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
-					}
-				}
-				if result == nil {
-					result = ingressNetworkingV1
-				}
-			} else if !paasErrors.IsNotFound(err) {
-				logger.ErrorC(ctx, "Error to get ingress before update: %+v", err)
+			ingressExists = true
+			ingressToUpdate := route.ToIngressNetworkingV1()
+			ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
+			if className := ingressToUpdate.Spec.IngressClassName; className == nil || *className == "" {
+				ingressToUpdate.Spec.IngressClassName = originalIngress.Spec.IngressClassName
+			}
+			kube.configureIngress(ingressToUpdate)
+			updatedIngress, err := kube.getNetworkingV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
+			if err != nil {
+				logger.ErrorC(ctx, "Error to update ingress: %+v", err)
 				return nil, err
+			}
+			logger.InfoC(ctx, "Ingress updated: %s", route.Name)
+			ingressNetworkingV1 := entity.RouteFromIngressNetworkingV1(updatedIngress)
+			if kube.Cache.Ingresses != nil && ingressNetworkingV1 != nil {
+				_, err := kube.Cache.Ingresses.Set(ctx, *ingressNetworkingV1)
+				if err != nil {
+					return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
+				}
+			}
+			if result == nil {
+				result = ingressNetworkingV1
 			}
 		} else {
 			originalIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Get(ctx, route.Name, v1.GetOptions{})
-			if err == nil {
-				ingressExists = true
-				ingressToUpdate := route.ToIngress()
-				ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
-				kube.configureIngress(ingressToUpdate)
-
-				updatedIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
-				if err != nil {
-					logger.ErrorC(ctx, "Error to update ingress: %+v", err)
+			if err != nil {
+				if !paasErrors.IsNotFound(err) {
+					logger.ErrorC(ctx, "Error to get ingress before update: %+v", err)
 					return nil, err
 				}
-				logger.InfoC(ctx, "Ingress updated: %s", route.Name)
-
-				routeFromIngress := entity.RouteFromIngress(updatedIngress)
-				if kube.Cache.Ingresses != nil && routeFromIngress != nil {
-					_, err := kube.Cache.Ingresses.Set(ctx, *routeFromIngress)
-					if err != nil {
-						return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
-					}
-				}
-				if result == nil {
-					result = routeFromIngress
-				}
-			} else if !paasErrors.IsNotFound(err) {
-				logger.ErrorC(ctx, "Error to get ingress before update: %+v", err)
+			}
+			ingressExists = true
+			ingressToUpdate := route.ToIngress()
+			ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
+			kube.configureIngress(ingressToUpdate)
+			updatedIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
+			if err != nil {
+				logger.ErrorC(ctx, "Error to update ingress: %+v", err)
 				return nil, err
+			}
+			logger.InfoC(ctx, "Ingress updated: %s", route.Name)
+			routeFromIngress := entity.RouteFromIngress(updatedIngress)
+			if kube.Cache.Ingresses != nil && routeFromIngress != nil {
+				_, err := kube.Cache.Ingresses.Set(ctx, *routeFromIngress)
+				if err != nil {
+					return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
+				}
+			}
+			if result == nil {
+				result = routeFromIngress
 			}
 		}
 	}

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -19,6 +19,7 @@ import (
 var BG2IngressClassName = "bg.mesh.netcracker.com"
 
 const IgnoreApiConverterAnnotation = "gateway-api-converter.netcracker.com/ignore"
+const errPlaceIngressIntoCache = "failed to place ingress into cache: %w"
 
 const (
 	AnnotationBackendProtocol   = "nginx.ingress.kubernetes.io/backend-protocol"
@@ -77,38 +78,51 @@ func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, na
 
 func (kube *Kubernetes) createRouteLegacyIngress(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
 	if kube.UseNetworkingV1Ingress {
-		ingress := route.ToIngressNetworkingV1()
-		kube.configureIngress(ingress)
-
-		createdIngress, err := kube.getNetworkingV1Client().Ingresses(namespace).Create(ctx, ingress, v1.CreateOptions{})
-		if err != nil {
-			logger.ErrorC(ctx, "Error to create ingress: %+v", err)
-			return nil, err
-		}
-		ingressNetworkingV1 := entity.RouteFromIngressNetworkingV1(createdIngress)
-		if kube.Cache.Ingresses != nil && ingressNetworkingV1 != nil {
-			if _, err := kube.Cache.Ingresses.Set(ctx, *ingressNetworkingV1); err != nil {
-				return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
-			}
-		}
-		return ingressNetworkingV1, nil
-	} else {
-		ingress := route.ToIngress()
-		kube.configureIngress(ingress)
-
-		createdIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Create(ctx, ingress, v1.CreateOptions{})
-		if err != nil {
-			logger.ErrorC(ctx, "Error to create ingress: %+v", err)
-			return nil, err
-		}
-		routeFromIngress := entity.RouteFromIngress(createdIngress)
-		if kube.Cache.Ingresses != nil && routeFromIngress != nil {
-			if _, err := kube.Cache.Ingresses.Set(ctx, *routeFromIngress); err != nil {
-				return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
-			}
-		}
-		return routeFromIngress, nil
+		return kube.createNetworkingV1IngressRoute(ctx, route, namespace)
 	}
+	return kube.createExtensionsV1IngressRoute(ctx, route, namespace)
+}
+
+func (kube *Kubernetes) cacheIngressRoute(ctx context.Context, route *entity.Route) error {
+	if kube.Cache.Ingresses == nil || route == nil {
+		return nil
+	}
+	if _, err := kube.Cache.Ingresses.Set(ctx, *route); err != nil {
+		return fmt.Errorf(errPlaceIngressIntoCache, err)
+	}
+	return nil
+}
+
+func (kube *Kubernetes) createNetworkingV1IngressRoute(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
+	ingress := route.ToIngressNetworkingV1()
+	kube.configureIngress(ingress)
+
+	createdIngress, err := kube.getNetworkingV1Client().Ingresses(namespace).Create(ctx, ingress, v1.CreateOptions{})
+	if err != nil {
+		logger.ErrorC(ctx, "Error to create ingress: %+v", err)
+		return nil, err
+	}
+	ingressRoute := entity.RouteFromIngressNetworkingV1(createdIngress)
+	if err := kube.cacheIngressRoute(ctx, ingressRoute); err != nil {
+		return nil, err
+	}
+	return ingressRoute, nil
+}
+
+func (kube *Kubernetes) createExtensionsV1IngressRoute(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
+	ingress := route.ToIngress()
+	kube.configureIngress(ingress)
+
+	createdIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Create(ctx, ingress, v1.CreateOptions{})
+	if err != nil {
+		logger.ErrorC(ctx, "Error to create ingress: %+v", err)
+		return nil, err
+	}
+	ingressRoute := entity.RouteFromIngress(createdIngress)
+	if err := kube.cacheIngressRoute(ctx, ingressRoute); err != nil {
+		return nil, err
+	}
+	return ingressRoute, nil
 }
 
 func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
@@ -186,7 +200,7 @@ func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.R
 			if kube.Cache.Ingresses != nil && ingressNetworkingV1 != nil {
 				_, err := kube.Cache.Ingresses.Set(ctx, *ingressNetworkingV1)
 				if err != nil {
-					return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
+					return nil, fmt.Errorf(errPlaceIngressIntoCache, err)
 				}
 			}
 			if result == nil {
@@ -218,7 +232,7 @@ func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.R
 			if kube.Cache.Ingresses != nil && routeFromIngress != nil {
 				_, err := kube.Cache.Ingresses.Set(ctx, *routeFromIngress)
 				if err != nil {
-					return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
+					return nil, fmt.Errorf(errPlaceIngressIntoCache, err)
 				}
 			}
 			if result == nil {

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/netcracker/qubership-core-lib-go-paas-mediation-client/v8/entity"
 	"github.com/netcracker/qubership-core-lib-go-paas-mediation-client/v8/filter"
@@ -17,14 +18,45 @@ import (
 var BG2IngressClassName = "bg.mesh.netcracker.com"
 
 func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
+	useGatewayAPI := kube.shouldUseGatewayAPI()
+	useLegacyIngress := kube.shouldCreateLegacyIngress()
+
+	if !useGatewayAPI && !useLegacyIngress {
+		return nil, fmt.Errorf("GATEWAY_SYSTEM_TYPE=%s does not allow any Route creation", kube.GatewaySystemType)
+	}
+
+	var result *entity.Route
+	var err error
+
+	if useGatewayAPI {
+		result, err = kube.createHTTPRoute(ctx, route, namespace)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create HTTPRoute: %w", err)
+		}
+		logger.InfoC(ctx, "HTTPRoute created: %s", route.Name)
+	}
+
+	if !useLegacyIngress {
+		return result, nil
+	}
+
 	if kube.UseNetworkingV1Ingress {
 		ingress := route.ToIngressNetworkingV1()
 		kube.modifyIngressClassForBG2(ingress)
+
+		if kube.shouldIgnoreIngressForConverter() {
+			if ingress.Annotations == nil {
+				ingress.Annotations = make(map[string]string)
+			}
+			ingress.Annotations["gateway-api-converter.netcracker.com/ignore"] = "true"
+		}
+
 		createdIngress, e := kube.getNetworkingV1Client().Ingresses(namespace).Create(ctx, ingress, v1.CreateOptions{})
 		if e != nil {
 			logger.ErrorC(ctx, "Error to create ingress: %+v", e)
 			return nil, e
 		}
+		logger.InfoC(ctx, "Ingress created: %s", route.Name)
 		ingressNetworkingV1 := entity.RouteFromIngressNetworkingV1(createdIngress)
 		if kube.Cache.Ingresses != nil && ingressNetworkingV1 != nil {
 			_, e := kube.Cache.Ingresses.Set(ctx, *ingressNetworkingV1)
@@ -36,11 +68,20 @@ func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, na
 	} else {
 		ingress := route.ToIngress()
 		kube.modifyIngressClassForBG2(ingress)
+
+		if kube.shouldIgnoreIngressForConverter() {
+			if ingress.Annotations == nil {
+				ingress.Annotations = make(map[string]string)
+			}
+			ingress.Annotations["gateway-api-converter.netcracker.com/ignore"] = "true"
+		}
+
 		createdIngress, e := kube.getExtensionsV1Client().Ingresses(namespace).Create(ctx, ingress, v1.CreateOptions{})
 		if e != nil {
 			logger.ErrorC(ctx, "Error to create ingress: %+v", e)
 			return nil, e
 		}
+		logger.InfoC(ctx, "Ingress created: %s", route.Name)
 		routeFromIngress := entity.RouteFromIngress(createdIngress)
 		if kube.Cache.Ingresses != nil && routeFromIngress != nil {
 			_, e := kube.Cache.Ingresses.Set(ctx, *routeFromIngress)
@@ -243,4 +284,50 @@ func (kube *Kubernetes) modifyIngressClassForBG2(ingress any) {
 			i.Spec.IngressClassName = &BG2IngressClassName
 		}
 	}
+}
+
+func (kube *Kubernetes) shouldUseGatewayAPI() bool {
+	if kube.GatewaySystemType == "" {
+		return false
+	}
+	return strings.Contains(kube.GatewaySystemType, "gateway-api-default")
+}
+
+func (kube *Kubernetes) shouldCreateLegacyIngress() bool {
+	if kube.GatewaySystemType == "" {
+		return true
+	}
+	return strings.Contains(kube.GatewaySystemType, "legacy-ingress")
+}
+
+func (kube *Kubernetes) shouldIgnoreIngressForConverter() bool {
+	if kube.GatewaySystemType == "" {
+		return false
+	}
+	return strings.Contains(kube.GatewaySystemType, "legacy-ingress") &&
+		strings.Contains(kube.GatewaySystemType, "gateway-api-default")
+}
+
+func (kube *Kubernetes) createHTTPRoute(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
+	httpRoute := route.ToHTTPRoute(
+		kube.GatewaySystemNamespace,
+		kube.GatewaySystemName,
+	)
+
+	createdHTTPRoute, err := kube.getGatewayV1Client().HTTPRoutes(namespace).Create(ctx, httpRoute, v1.CreateOptions{})
+	if err != nil {
+		logger.ErrorC(ctx, "Error to create HTTPRoute: %+v", err)
+		return nil, err
+	}
+
+	routeFromHTTPRoute := entity.RouteFromHTTPRouteGatewayV1(createdHTTPRoute)
+	if kube.Cache.HTTPRoute != nil && routeFromHTTPRoute != nil {
+		httpRouteEntity := entity.RouteFromHTTPRoute(createdHTTPRoute)
+		_, err := kube.Cache.HTTPRoute.Set(ctx, *httpRouteEntity)
+		if err != nil {
+			return nil, fmt.Errorf("failed to place HTTPRoute into cache: %w", err)
+		}
+	}
+
+	return routeFromHTTPRoute, nil
 }

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -118,26 +118,28 @@ func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.R
 				logger.ErrorC(ctx, "Error to get HTTPRoute before update: %+v", err)
 				return nil, err
 			}
-		}
-		httpRouteExists = true
-		httpRouteToUpdate := route.ToHTTPRoute(kube.GatewaySystem.Namespace, kube.GatewaySystem.Name)
-		httpRouteToUpdate.ResourceVersion = originalHTTPRoute.ResourceVersion
-		updatedHTTPRoute, err := kube.getGatewayV1Client().HTTPRoutes(namespace).Update(ctx, httpRouteToUpdate, v1.UpdateOptions{})
-		if err != nil {
-			logger.ErrorC(ctx, "Error to update HTTPRoute: %+v", err)
-			return nil, err
-		}
-		logger.InfoC(ctx, "HTTPRoute updated: %s", route.Name)
-		routeFromHTTPRoute := entity.RouteFromHTTPRoute(updatedHTTPRoute)
-		if kube.Cache.HTTPRoute != nil && routeFromHTTPRoute != nil {
-			httpRouteEntity := entity.WrapHTTPRoute(updatedHTTPRoute)
-			_, err := kube.Cache.HTTPRoute.Set(ctx, *httpRouteEntity)
-			if err != nil {
-				return nil, fmt.Errorf("failed to place HTTPRoute into cache: %w", err)
-			}
-		}
-		result = routeFromHTTPRoute
+		} else {
+			httpRouteExists = true
+			httpRouteToUpdate := route.ToHTTPRoute(kube.GatewaySystem.Namespace, kube.GatewaySystem.Name)
+			httpRouteToUpdate.ResourceVersion = originalHTTPRoute.ResourceVersion
 
+			updatedHTTPRoute, err := kube.getGatewayV1Client().HTTPRoutes(namespace).Update(ctx, httpRouteToUpdate, v1.UpdateOptions{})
+			if err != nil {
+				logger.ErrorC(ctx, "Error to update HTTPRoute: %+v", err)
+				return nil, err
+			}
+			logger.InfoC(ctx, "HTTPRoute updated: %s", route.Name)
+
+			routeFromHTTPRoute := entity.RouteFromHTTPRoute(updatedHTTPRoute)
+			if kube.Cache.HTTPRoute != nil && routeFromHTTPRoute != nil {
+				httpRouteEntity := entity.WrapHTTPRoute(updatedHTTPRoute)
+				_, err := kube.Cache.HTTPRoute.Set(ctx, *httpRouteEntity)
+				if err != nil {
+					return nil, fmt.Errorf("failed to place HTTPRoute into cache: %w", err)
+				}
+			}
+			result = routeFromHTTPRoute
+		}
 	}
 
 	if useLegacyIngress {
@@ -148,30 +150,32 @@ func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.R
 					logger.ErrorC(ctx, "Error to get ingress before update: %+v", err)
 					return nil, err
 				}
-			}
-
-			ingressExists = true
-			ingressToUpdate := route.ToIngressNetworkingV1()
-			ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
-			if className := ingressToUpdate.Spec.IngressClassName; className == nil || *className == "" {
-				ingressToUpdate.Spec.IngressClassName = originalIngress.Spec.IngressClassName
-			}
-			kube.configureIngress(ingressToUpdate)
-			updatedIngress, err := kube.getNetworkingV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
-			if err != nil {
-				logger.ErrorC(ctx, "Error to update ingress: %+v", err)
-				return nil, err
-			}
-			logger.InfoC(ctx, "Ingress updated: %s", route.Name)
-			ingressNetworkingV1 := entity.RouteFromIngressNetworkingV1(updatedIngress)
-			if kube.Cache.Ingresses != nil && ingressNetworkingV1 != nil {
-				_, err := kube.Cache.Ingresses.Set(ctx, *ingressNetworkingV1)
-				if err != nil {
-					return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
+			} else {
+				ingressExists = true
+				ingressToUpdate := route.ToIngressNetworkingV1()
+				ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
+				if className := ingressToUpdate.Spec.IngressClassName; className == nil || *className == "" {
+					ingressToUpdate.Spec.IngressClassName = originalIngress.Spec.IngressClassName
 				}
-			}
-			if result == nil {
-				result = ingressNetworkingV1
+				kube.configureIngress(ingressToUpdate)
+
+				updatedIngress, err := kube.getNetworkingV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
+				if err != nil {
+					logger.ErrorC(ctx, "Error to update ingress: %+v", err)
+					return nil, err
+				}
+				logger.InfoC(ctx, "Ingress updated: %s", route.Name)
+
+				ingressNetworkingV1 := entity.RouteFromIngressNetworkingV1(updatedIngress)
+				if kube.Cache.Ingresses != nil && ingressNetworkingV1 != nil {
+					_, err := kube.Cache.Ingresses.Set(ctx, *ingressNetworkingV1)
+					if err != nil {
+						return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
+					}
+				}
+				if result == nil {
+					result = ingressNetworkingV1
+				}
 			}
 		} else {
 			originalIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Get(ctx, route.Name, v1.GetOptions{})
@@ -180,26 +184,29 @@ func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.R
 					logger.ErrorC(ctx, "Error to get ingress before update: %+v", err)
 					return nil, err
 				}
-			}
-			ingressExists = true
-			ingressToUpdate := route.ToIngress()
-			ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
-			kube.configureIngress(ingressToUpdate)
-			updatedIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
-			if err != nil {
-				logger.ErrorC(ctx, "Error to update ingress: %+v", err)
-				return nil, err
-			}
-			logger.InfoC(ctx, "Ingress updated: %s", route.Name)
-			routeFromIngress := entity.RouteFromIngress(updatedIngress)
-			if kube.Cache.Ingresses != nil && routeFromIngress != nil {
-				_, err := kube.Cache.Ingresses.Set(ctx, *routeFromIngress)
+			} else {
+				ingressExists = true
+				ingressToUpdate := route.ToIngress()
+				ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
+				kube.configureIngress(ingressToUpdate)
+
+				updatedIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
 				if err != nil {
-					return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
+					logger.ErrorC(ctx, "Error to update ingress: %+v", err)
+					return nil, err
 				}
-			}
-			if result == nil {
-				result = routeFromIngress
+				logger.InfoC(ctx, "Ingress updated: %s", route.Name)
+
+				routeFromIngress := entity.RouteFromIngress(updatedIngress)
+				if kube.Cache.Ingresses != nil && routeFromIngress != nil {
+					_, err := kube.Cache.Ingresses.Set(ctx, *routeFromIngress)
+					if err != nil {
+						return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
+					}
+				}
+				if result == nil {
+					result = routeFromIngress
+				}
 			}
 		}
 	}

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -20,6 +20,8 @@ var BG2IngressClassName = "bg.mesh.netcracker.com"
 
 const IgnoreApiConverterAnnotation = "gateway-api-converter.netcracker.com/ignore"
 const errPlaceIngressIntoCache = "failed to place ingress into cache: %w"
+const IngressCreated = "Ingress created: %s"
+const RouteDeleteFailed = "Route delete failed: %s"
 
 const (
 	AnnotationBackendProtocol   = "nginx.ingress.kubernetes.io/backend-protocol"
@@ -72,7 +74,7 @@ func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, na
 		routeResult, err := kube.createRouteLegacyIngress(ctx, route, namespace)
 		ingressRes = routeResourceResult{route: routeResult, status: routeStatusCreated, err: err}
 		if err == nil {
-			logger.InfoC(ctx, "Ingress created: %s", route.Name)
+			logger.InfoC(ctx, IngressCreated, route.Name)
 		}
 	}
 
@@ -147,14 +149,11 @@ func formatDualModeDeleteRouteStatus(httpRouteErr, ingressErr error) string {
 }
 
 func routeResourceDeleteStatus(name string, err error) string {
-	switch {
-	case err == nil:
+	if err == nil {
 		return name + ": deleted"
-	case paasErrors.IsNotFound(err):
-		return name + ": not found"
-	default:
-		return fmt.Sprintf("%s: error: %v", name, err)
 	}
+
+	return fmt.Sprintf("%s: error: %v", name, err)
 }
 
 func (kube *Kubernetes) createRouteLegacyIngress(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
@@ -276,7 +275,7 @@ func (kube *Kubernetes) upsertNetworkingV1Ingress(ctx context.Context, route *en
 			logger.WarnC(ctx, "Ingress %s not found. Creating new", route.Name)
 			ingressResult, createErr := kube.createRouteLegacyIngress(ctx, route, namespace)
 			if createErr == nil {
-				logger.InfoC(ctx, "Ingress created: %s", route.Name)
+				logger.InfoC(ctx, IngressCreated, route.Name)
 			}
 			return routeResourceResult{route: ingressResult, status: routeStatusCreated, err: createErr}
 		}
@@ -312,7 +311,7 @@ func (kube *Kubernetes) upsertExtensionsV1Ingress(ctx context.Context, route *en
 			logger.WarnC(ctx, "Ingress %s not found. Creating new", route.Name)
 			ingressResult, createErr := kube.createRouteLegacyIngress(ctx, route, namespace)
 			if createErr == nil {
-				logger.InfoC(ctx, "Ingress created: %s", route.Name)
+				logger.InfoC(ctx, IngressCreated, route.Name)
 			}
 			return routeResourceResult{route: ingressResult, status: routeStatusCreated, err: createErr}
 		}
@@ -375,12 +374,12 @@ func resolveDeleteRouteResult(
 		status := formatDualModeDeleteRouteStatus(httpRouteErr, ingressErr)
 
 		if paasErrors.IsNotFound(httpRouteErr) && paasErrors.IsNotFound(ingressErr) {
-			logger.Warn("Route delete failed: %s", status)
+			logger.Warn(RouteDeleteFailed, status)
 			return newRouteDeleteNotFoundError(routeName, status)
 		}
 
 		if isDeleteFailure(httpRouteErr) || isDeleteFailure(ingressErr) {
-			logger.Error("Route delete failed: %s", status)
+			logger.Error(RouteDeleteFailed, status)
 			return paasErrors.NewInternalError(fmt.Errorf("%s", status))
 		}
 
@@ -406,10 +405,10 @@ func resolveSingleResourceDeleteResult(resourceName string, err error) error {
 		return nil
 	}
 	if isDeleteFailure(err) {
-		logger.Error("Route delete failed: %s", status)
+		logger.Error(RouteDeleteFailed, status)
 		return paasErrors.NewInternalError(fmt.Errorf("%s", status))
 	}
-	logger.Warn("Route delete failed: %s", status)
+	logger.Warn(RouteDeleteFailed, status)
 	return err
 }
 

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -30,6 +30,12 @@ const (
 	AnnotationUpstreamVhost     = "nginx.ingress.kubernetes.io/upstream-vhost"
 	AnnotationProxyRedirectFrom = "nginx.ingress.kubernetes.io/proxy-redirect-from"
 	AnnotationProxyRedirectTo   = "nginx.ingress.kubernetes.io/proxy-redirect-to"
+	EnvoyExtensionWarning       = "requires EnvoyExtensionPolicy with Lua"
+	BackendTLSWarning           = "requires BackendTLSPolicy"
+	BackendTlsOrTrafficWarning  = "requires BackendTLSPolicy (for HTTPS) or BackendTrafficPolicy (for GRPC)."
+	SecurityPolicyWarning       = "requires SecurityPolicy"
+	TlsRouteWarning             = "requires TLSRoute instead of HTTPRoute"
+	ConfigSnippetWarning        = "requires manual conversion using RequestHeaderModifier/ResponseHeaderModifier filters"
 )
 
 func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
@@ -424,14 +430,14 @@ func (kube *Kubernetes) shouldIgnoreIngressForConverter() bool {
 
 func (kube *Kubernetes) validateAnnotationsForGatewayAPI(annotations map[string]string) error {
 	criticalAnnotations := map[string]string{
-		AnnotationBackendProtocol:   "requires BackendTLSPolicy (for HTTPS) or BackendTrafficPolicy (for GRPC).",
-		AnnotationSecureBackends:    "requires BackendTLSPolicy.",
-		AnnotationAuthType:          "requires SecurityPolicy.",
-		AnnotationSSLPassthrough:    "requires TLSRoute instead of HTTPRoute. See GatewayAPIMigration.md section 12",
-		AnnotationConfigSnippet:     "requires manual conversion using RequestHeaderModifier/ResponseHeaderModifier filters.",
-		AnnotationUpstreamVhost:     "requires EnvoyExtensionPolicy with Lua.",
-		AnnotationProxyRedirectFrom: "requires EnvoyExtensionPolicy with Lua.",
-		AnnotationProxyRedirectTo:   "requires EnvoyExtensionPolicy with Lua.",
+		AnnotationBackendProtocol:   BackendTlsOrTrafficWarning,
+		AnnotationSecureBackends:    BackendTLSWarning,
+		AnnotationAuthType:          SecurityPolicyWarning,
+		AnnotationSSLPassthrough:    TlsRouteWarning,
+		AnnotationConfigSnippet:     ConfigSnippetWarning,
+		AnnotationUpstreamVhost:     EnvoyExtensionWarning,
+		AnnotationProxyRedirectFrom: EnvoyExtensionWarning,
+		AnnotationProxyRedirectTo:   EnvoyExtensionWarning,
 	}
 
 	for key, message := range criticalAnnotations {

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -18,6 +18,11 @@ import (
 var BG2IngressClassName = "bg.mesh.netcracker.com"
 var IgnoreApiConverterAnnotation = "gateway-api-converter.netcracker.com/ignore"
 
+const (
+	LegacyIngress     = "legacy-ingress"
+	GatewayApiDefault = "gateway-api-default"
+)
+
 func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
 	useGatewayAPI := kube.shouldUseGatewayAPI()
 	useLegacyIngress := kube.shouldCreateLegacyIngress()
@@ -387,22 +392,22 @@ func (kube *Kubernetes) shouldUseGatewayAPI() bool {
 	if kube.GatewaySystemType == "" {
 		return false
 	}
-	return strings.Contains(kube.GatewaySystemType, "gateway-api-default")
+	return strings.Contains(kube.GatewaySystemType, GatewayApiDefault)
 }
 
 func (kube *Kubernetes) shouldCreateLegacyIngress() bool {
 	if kube.GatewaySystemType == "" {
 		return true
 	}
-	return strings.Contains(kube.GatewaySystemType, "legacy-ingress")
+	return strings.Contains(kube.GatewaySystemType, LegacyIngress)
 }
 
 func (kube *Kubernetes) shouldIgnoreIngressForConverter() bool {
 	if kube.GatewaySystemType == "" {
 		return false
 	}
-	return strings.Contains(kube.GatewaySystemType, "legacy-ingress") &&
-		strings.Contains(kube.GatewaySystemType, "gateway-api-default")
+	return strings.Contains(kube.GatewaySystemType, LegacyIngress) &&
+		strings.Contains(kube.GatewaySystemType, GatewayApiDefault)
 }
 
 func (kube *Kubernetes) createHTTPRoute(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -21,6 +21,15 @@ var IgnoreApiConverterAnnotation = "gateway-api-converter.netcracker.com/ignore"
 const (
 	LegacyIngress     = "legacy-ingress"
 	GatewayApiDefault = "gateway-api-default"
+
+	AnnotationBackendProtocol   = "nginx.ingress.kubernetes.io/backend-protocol"
+	AnnotationSecureBackends    = "nginx.ingress.kubernetes.io/secure-backends"
+	AnnotationAuthType          = "nginx.ingress.kubernetes.io/auth-type"
+	AnnotationSSLPassthrough    = "nginx.ingress.kubernetes.io/ssl-passthrough"
+	AnnotationConfigSnippet     = "nginx.ingress.kubernetes.io/configuration-snippet"
+	AnnotationUpstreamVhost     = "nginx.ingress.kubernetes.io/upstream-vhost"
+	AnnotationProxyRedirectFrom = "nginx.ingress.kubernetes.io/proxy-redirect-from"
+	AnnotationProxyRedirectTo   = "nginx.ingress.kubernetes.io/proxy-redirect-to"
 )
 
 func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
@@ -35,6 +44,9 @@ func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, na
 	var err error
 
 	if useGatewayAPI {
+		if err = kube.validateAnnotationsForGatewayAPI(route.Metadata.Annotations); err != nil {
+			return nil, err
+		}
 		result, err = kube.createHTTPRoute(ctx, route, namespace)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create HTTPRoute: %w", err)
@@ -408,6 +420,27 @@ func (kube *Kubernetes) shouldIgnoreIngressForConverter() bool {
 	}
 	return strings.Contains(kube.GatewaySystemType, LegacyIngress) &&
 		strings.Contains(kube.GatewaySystemType, GatewayApiDefault)
+}
+
+func (kube *Kubernetes) validateAnnotationsForGatewayAPI(annotations map[string]string) error {
+	criticalAnnotations := map[string]string{
+		AnnotationBackendProtocol:   "requires BackendTLSPolicy (for HTTPS) or BackendTrafficPolicy (for GRPC).",
+		AnnotationSecureBackends:    "requires BackendTLSPolicy.",
+		AnnotationAuthType:          "requires SecurityPolicy.",
+		AnnotationSSLPassthrough:    "requires TLSRoute instead of HTTPRoute. See GatewayAPIMigration.md section 12",
+		AnnotationConfigSnippet:     "requires manual conversion using RequestHeaderModifier/ResponseHeaderModifier filters.",
+		AnnotationUpstreamVhost:     "requires EnvoyExtensionPolicy with Lua.",
+		AnnotationProxyRedirectFrom: "requires EnvoyExtensionPolicy with Lua.",
+		AnnotationProxyRedirectTo:   "requires EnvoyExtensionPolicy with Lua.",
+	}
+
+	for key, message := range criticalAnnotations {
+		if val, exists := annotations[key]; exists && val != "" {
+			return fmt.Errorf("annotation '%s' is not supported for HTTPRoute creation: %s", key, message)
+		}
+	}
+
+	return nil
 }
 
 func (kube *Kubernetes) createHTTPRoute(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -114,99 +114,103 @@ func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.R
 	if useGatewayAPI {
 		originalHTTPRoute, err := kube.getGatewayV1Client().HTTPRoutes(namespace).Get(ctx, route.Name, v1.GetOptions{})
 		if err != nil {
-			if !paasErrors.IsNotFound(err) {
-				logger.ErrorC(ctx, "Error to get HTTPRoute before update: %+v", err)
-				return nil, err
+			if paasErrors.IsNotFound(err) {
+				logger.WarnC(ctx, "HTTPRoute %s not found. Creating new", route.Name)
+				return kube.CreateRoute(ctx, route, namespace)
 			}
-		} else {
-			httpRouteExists = true
-			httpRouteToUpdate := route.ToHTTPRoute(kube.GatewaySystem.Namespace, kube.GatewaySystem.Name)
-			httpRouteToUpdate.ResourceVersion = originalHTTPRoute.ResourceVersion
-
-			updatedHTTPRoute, err := kube.getGatewayV1Client().HTTPRoutes(namespace).Update(ctx, httpRouteToUpdate, v1.UpdateOptions{})
-			if err != nil {
-				logger.ErrorC(ctx, "Error to update HTTPRoute: %+v", err)
-				return nil, err
-			}
-			logger.InfoC(ctx, "HTTPRoute updated: %s", route.Name)
-
-			routeFromHTTPRoute := entity.RouteFromHTTPRoute(updatedHTTPRoute)
-			if kube.Cache.HTTPRoute != nil && routeFromHTTPRoute != nil {
-				httpRouteEntity := entity.WrapHTTPRoute(updatedHTTPRoute)
-				_, err := kube.Cache.HTTPRoute.Set(ctx, *httpRouteEntity)
-				if err != nil {
-					return nil, fmt.Errorf("failed to place HTTPRoute into cache: %w", err)
-				}
-			}
-			result = routeFromHTTPRoute
+			logger.ErrorC(ctx, "Error to get HTTPRoute before update: %+v", err)
+			return nil, err
 		}
+		httpRouteExists = true
+		httpRouteToUpdate := route.ToHTTPRoute(kube.GatewaySystem.Namespace, kube.GatewaySystem.Name)
+		httpRouteToUpdate.ResourceVersion = originalHTTPRoute.ResourceVersion
+
+		updatedHTTPRoute, err := kube.getGatewayV1Client().HTTPRoutes(namespace).Update(ctx, httpRouteToUpdate, v1.UpdateOptions{})
+		if err != nil {
+			logger.ErrorC(ctx, "Error to update HTTPRoute: %+v", err)
+			return nil, err
+		}
+		logger.InfoC(ctx, "HTTPRoute updated: %s", route.Name)
+
+		routeFromHTTPRoute := entity.RouteFromHTTPRoute(updatedHTTPRoute)
+		if kube.Cache.HTTPRoute != nil && routeFromHTTPRoute != nil {
+			httpRouteEntity := entity.WrapHTTPRoute(updatedHTTPRoute)
+			_, err := kube.Cache.HTTPRoute.Set(ctx, *httpRouteEntity)
+			if err != nil {
+				return nil, fmt.Errorf("failed to place HTTPRoute into cache: %w", err)
+			}
+		}
+		result = routeFromHTTPRoute
 	}
 
 	if useLegacyIngress {
 		if kube.UseNetworkingV1Ingress {
 			originalIngress, err := kube.getNetworkingV1Client().Ingresses(namespace).Get(ctx, route.Name, v1.GetOptions{})
 			if err != nil {
-				if !paasErrors.IsNotFound(err) {
-					logger.ErrorC(ctx, "Error to get ingress before update: %+v", err)
-					return nil, err
+				if paasErrors.IsNotFound(err) {
+					logger.WarnC(ctx, "Ingress %s not found. Creating new", route.Name)
+					return kube.CreateRoute(ctx, route, namespace)
 				}
-			} else {
-				ingressExists = true
-				ingressToUpdate := route.ToIngressNetworkingV1()
-				ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
-				if className := ingressToUpdate.Spec.IngressClassName; className == nil || *className == "" {
-					ingressToUpdate.Spec.IngressClassName = originalIngress.Spec.IngressClassName
-				}
-				kube.configureIngress(ingressToUpdate)
+				logger.ErrorC(ctx, "Error to get ingress before update: %+v", err)
+				return nil, err
+			}
 
-				updatedIngress, err := kube.getNetworkingV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
+			ingressExists = true
+			ingressToUpdate := route.ToIngressNetworkingV1()
+			ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
+			if className := ingressToUpdate.Spec.IngressClassName; className == nil || *className == "" {
+				ingressToUpdate.Spec.IngressClassName = originalIngress.Spec.IngressClassName
+			}
+			kube.configureIngress(ingressToUpdate)
+
+			updatedIngress, err := kube.getNetworkingV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
+			if err != nil {
+				logger.ErrorC(ctx, "Error to update ingress: %+v", err)
+				return nil, err
+			}
+			logger.InfoC(ctx, "Ingress updated: %s", route.Name)
+
+			ingressNetworkingV1 := entity.RouteFromIngressNetworkingV1(updatedIngress)
+			if kube.Cache.Ingresses != nil && ingressNetworkingV1 != nil {
+				_, err := kube.Cache.Ingresses.Set(ctx, *ingressNetworkingV1)
 				if err != nil {
-					logger.ErrorC(ctx, "Error to update ingress: %+v", err)
-					return nil, err
+					return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
 				}
-				logger.InfoC(ctx, "Ingress updated: %s", route.Name)
-
-				ingressNetworkingV1 := entity.RouteFromIngressNetworkingV1(updatedIngress)
-				if kube.Cache.Ingresses != nil && ingressNetworkingV1 != nil {
-					_, err := kube.Cache.Ingresses.Set(ctx, *ingressNetworkingV1)
-					if err != nil {
-						return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
-					}
-				}
-				if result == nil {
-					result = ingressNetworkingV1
-				}
+			}
+			if result == nil {
+				result = ingressNetworkingV1
 			}
 		} else {
 			originalIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Get(ctx, route.Name, v1.GetOptions{})
 			if err != nil {
-				if !paasErrors.IsNotFound(err) {
-					logger.ErrorC(ctx, "Error to get ingress before update: %+v", err)
-					return nil, err
+				if paasErrors.IsNotFound(err) {
+					logger.WarnC(ctx, "Ingress %s not found. Creating new", route.Name)
+					return kube.CreateRoute(ctx, route, namespace)
 				}
-			} else {
-				ingressExists = true
-				ingressToUpdate := route.ToIngress()
-				ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
-				kube.configureIngress(ingressToUpdate)
+				logger.ErrorC(ctx, "Error to get ingress before update: %+v", err)
+				return nil, err
+			}
+			ingressExists = true
+			ingressToUpdate := route.ToIngress()
+			ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
+			kube.configureIngress(ingressToUpdate)
 
-				updatedIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
+			updatedIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
+			if err != nil {
+				logger.ErrorC(ctx, "Error to update ingress: %+v", err)
+				return nil, err
+			}
+			logger.InfoC(ctx, "Ingress updated: %s", route.Name)
+
+			routeFromIngress := entity.RouteFromIngress(updatedIngress)
+			if kube.Cache.Ingresses != nil && routeFromIngress != nil {
+				_, err := kube.Cache.Ingresses.Set(ctx, *routeFromIngress)
 				if err != nil {
-					logger.ErrorC(ctx, "Error to update ingress: %+v", err)
-					return nil, err
+					return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
 				}
-				logger.InfoC(ctx, "Ingress updated: %s", route.Name)
-
-				routeFromIngress := entity.RouteFromIngress(updatedIngress)
-				if kube.Cache.Ingresses != nil && routeFromIngress != nil {
-					_, err := kube.Cache.Ingresses.Set(ctx, *routeFromIngress)
-					if err != nil {
-						return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
-					}
-				}
-				if result == nil {
-					result = routeFromIngress
-				}
+			}
+			if result == nil {
+				result = routeFromIngress
 			}
 		}
 	}

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -37,6 +37,10 @@ const (
 	ConfigSnippetWarning        = "requires manual conversion using RequestHeaderModifier/ResponseHeaderModifier filters"
 )
 
+const (
+	partialRouteCreateMsg = "HTTPRoute route was created, Ingress route was not created - try using Update endpoint"
+)
+
 func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
 	if !kube.GatewaySystem.IsRouteCreationAllowed() {
 		return nil, kube.GatewaySystem.RouteCreationNotAllowedError()
@@ -45,36 +49,46 @@ func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, na
 	useGatewayAPI := kube.GatewaySystem.IsGatewayAPIEnabled()
 	useLegacyIngress := kube.GatewaySystem.IsIngressEnabled()
 
-	var result *entity.Route
-	var err error
+	var httpRouteResult *entity.Route
 
 	if useGatewayAPI {
-		result, err = kube.createHTTPRoute(ctx, route, namespace)
+		var err error
+		httpRouteResult, err = kube.createHTTPRoute(ctx, route, namespace)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create HTTPRoute: %w", err)
 		}
 		logger.InfoC(ctx, "HTTPRoute created: %s", route.Name)
 	}
 
-	if !useLegacyIngress {
-		return result, nil
+	if useLegacyIngress {
+		ingressResult, ingressErr := kube.createRouteLegacyIngress(ctx, route, namespace)
+		if ingressErr != nil {
+			if useGatewayAPI {
+				return nil, paasErrors.NewInternalError(fmt.Errorf(partialRouteCreateMsg))
+			}
+			return nil, ingressErr
+		}
+		logger.InfoC(ctx, "Ingress created: %s", route.Name)
+		return ingressResult, nil
 	}
 
+	return httpRouteResult, nil
+}
+
+func (kube *Kubernetes) createRouteLegacyIngress(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
 	if kube.UseNetworkingV1Ingress {
 		ingress := route.ToIngressNetworkingV1()
 		kube.configureIngress(ingress)
 
-		createdIngress, e := kube.getNetworkingV1Client().Ingresses(namespace).Create(ctx, ingress, v1.CreateOptions{})
-		if e != nil {
-			logger.ErrorC(ctx, "Error to create ingress: %+v", e)
-			return nil, e
+		createdIngress, err := kube.getNetworkingV1Client().Ingresses(namespace).Create(ctx, ingress, v1.CreateOptions{})
+		if err != nil {
+			logger.ErrorC(ctx, "Error to create ingress: %+v", err)
+			return nil, err
 		}
-		logger.InfoC(ctx, "Ingress created: %s", route.Name)
 		ingressNetworkingV1 := entity.RouteFromIngressNetworkingV1(createdIngress)
 		if kube.Cache.Ingresses != nil && ingressNetworkingV1 != nil {
-			_, e := kube.Cache.Ingresses.Set(ctx, *ingressNetworkingV1)
-			if e != nil {
-				return nil, fmt.Errorf("faield to place ingress into cache: %w", e)
+			if _, err := kube.Cache.Ingresses.Set(ctx, *ingressNetworkingV1); err != nil {
+				return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
 			}
 		}
 		return ingressNetworkingV1, nil
@@ -82,17 +96,15 @@ func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, na
 		ingress := route.ToIngress()
 		kube.configureIngress(ingress)
 
-		createdIngress, e := kube.getExtensionsV1Client().Ingresses(namespace).Create(ctx, ingress, v1.CreateOptions{})
-		if e != nil {
-			logger.ErrorC(ctx, "Error to create ingress: %+v", e)
-			return nil, e
+		createdIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Create(ctx, ingress, v1.CreateOptions{})
+		if err != nil {
+			logger.ErrorC(ctx, "Error to create ingress: %+v", err)
+			return nil, err
 		}
-		logger.InfoC(ctx, "Ingress created: %s", route.Name)
 		routeFromIngress := entity.RouteFromIngress(createdIngress)
 		if kube.Cache.Ingresses != nil && routeFromIngress != nil {
-			_, e := kube.Cache.Ingresses.Set(ctx, *routeFromIngress)
-			if e != nil {
-				return nil, fmt.Errorf("faield to place ingress into cache: %w", e)
+			if _, err := kube.Cache.Ingresses.Set(ctx, *routeFromIngress); err != nil {
+				return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
 			}
 		}
 		return routeFromIngress, nil

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -94,62 +94,131 @@ func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, na
 }
 
 func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
-	if kube.UseNetworkingV1Ingress {
-		originalIngress, e := kube.getNetworkingV1Client().Ingresses(namespace).Get(ctx, route.Name, v1.GetOptions{})
-		if e != nil {
-			if paasErrors.IsNotFound(e) {
-				logger.WarnC(ctx, "Ingress %s not found. Creating new", route.Name)
-				return kube.CreateRoute(ctx, route, namespace)
-			}
-			logger.ErrorC(ctx, "Error to get ingress before update: %+v", e)
-			return nil, e
-		}
-		ingressToUpdate := route.ToIngressNetworkingV1()
-		ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
-		if className := ingressToUpdate.Spec.IngressClassName; className == nil || *className == "" {
-			ingressToUpdate.Spec.IngressClassName = originalIngress.Spec.IngressClassName
-		}
-		kube.modifyIngressClassForBG2(ingressToUpdate)
-		updatedIngress, e := kube.getNetworkingV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
-		if e != nil {
-			logger.ErrorC(ctx, "Error to update ingress: %+v", e)
-			return nil, e
-		}
-		ingressNetworkingV1 := entity.RouteFromIngressNetworkingV1(updatedIngress)
-		if kube.Cache.Ingresses != nil && ingressNetworkingV1 != nil {
-			_, e := kube.Cache.Ingresses.Set(ctx, *ingressNetworkingV1)
-			if e != nil {
-				return nil, fmt.Errorf("faield to place ingress into cache: %w", e)
-			}
-		}
-		return ingressNetworkingV1, nil
-	} else {
-		originalIngress, e := kube.getExtensionsV1Client().Ingresses(namespace).Get(ctx, route.Name, v1.GetOptions{})
-		if e != nil {
-			if paasErrors.IsNotFound(e) {
-				logger.WarnC(ctx, "Ingress %s not found. Creating new", route.Name)
-				return kube.CreateRoute(ctx, route, namespace)
-			}
-			logger.ErrorC(ctx, "Error to get ingress before update: %+v", e)
-			return nil, e
-		}
-		ingressToUpdate := route.ToIngress()
-		ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
-		kube.modifyIngressClassForBG2(ingressToUpdate)
-		updatedIngress, e := kube.getExtensionsV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
-		if e != nil {
-			logger.ErrorC(ctx, "Error to update ingress: %+v", e)
-			return nil, e
-		}
-		routeFromIngress := entity.RouteFromIngress(updatedIngress)
-		if kube.Cache.Ingresses != nil && routeFromIngress != nil {
-			_, e := kube.Cache.Ingresses.Set(ctx, *routeFromIngress)
-			if e != nil {
-				return nil, fmt.Errorf("faield to place ingress into cache: %w", e)
-			}
-		}
-		return routeFromIngress, nil
+	useGatewayAPI := kube.shouldUseGatewayAPI()
+	useLegacyIngress := kube.shouldCreateLegacyIngress()
+
+	if !useGatewayAPI && !useLegacyIngress {
+		return nil, fmt.Errorf("GATEWAY_SYSTEM_TYPE=%s does not allow any Route update", kube.GatewaySystemType)
 	}
+
+	var result *entity.Route
+	var httpRouteExists bool
+	var ingressExists bool
+
+	if useGatewayAPI {
+		originalHTTPRoute, err := kube.getGatewayV1Client().HTTPRoutes(namespace).Get(ctx, route.Name, v1.GetOptions{})
+		if err == nil {
+			httpRouteExists = true
+			httpRouteToUpdate := route.ToHTTPRoute(kube.GatewaySystemNamespace, kube.GatewaySystemName)
+			httpRouteToUpdate.ResourceVersion = originalHTTPRoute.ResourceVersion
+
+			updatedHTTPRoute, err := kube.getGatewayV1Client().HTTPRoutes(namespace).Update(ctx, httpRouteToUpdate, v1.UpdateOptions{})
+			if err != nil {
+				logger.ErrorC(ctx, "Error to update HTTPRoute: %+v", err)
+				return nil, err
+			}
+			logger.InfoC(ctx, "HTTPRoute updated: %s", route.Name)
+
+			routeFromHTTPRoute := entity.RouteFromHTTPRouteGatewayV1(updatedHTTPRoute)
+			if kube.Cache.HTTPRoute != nil && routeFromHTTPRoute != nil {
+				httpRouteEntity := entity.RouteFromHTTPRoute(updatedHTTPRoute)
+				_, err := kube.Cache.HTTPRoute.Set(ctx, *httpRouteEntity)
+				if err != nil {
+					return nil, fmt.Errorf("failed to place HTTPRoute into cache: %w", err)
+				}
+			}
+			result = routeFromHTTPRoute
+		} else if !paasErrors.IsNotFound(err) {
+			logger.ErrorC(ctx, "Error to get HTTPRoute before update: %+v", err)
+			return nil, err
+		}
+	}
+
+	if useLegacyIngress {
+		if kube.UseNetworkingV1Ingress {
+			originalIngress, err := kube.getNetworkingV1Client().Ingresses(namespace).Get(ctx, route.Name, v1.GetOptions{})
+			if err == nil {
+				ingressExists = true
+				ingressToUpdate := route.ToIngressNetworkingV1()
+				ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
+				if className := ingressToUpdate.Spec.IngressClassName; className == nil || *className == "" {
+					ingressToUpdate.Spec.IngressClassName = originalIngress.Spec.IngressClassName
+				}
+				kube.modifyIngressClassForBG2(ingressToUpdate)
+
+				if kube.shouldIgnoreIngressForConverter() {
+					if ingressToUpdate.Annotations == nil {
+						ingressToUpdate.Annotations = make(map[string]string)
+					}
+					ingressToUpdate.Annotations["gateway-api-converter.netcracker.com/ignore"] = "true"
+				}
+
+				updatedIngress, err := kube.getNetworkingV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
+				if err != nil {
+					logger.ErrorC(ctx, "Error to update ingress: %+v", err)
+					return nil, err
+				}
+				logger.InfoC(ctx, "Ingress updated: %s", route.Name)
+
+				ingressNetworkingV1 := entity.RouteFromIngressNetworkingV1(updatedIngress)
+				if kube.Cache.Ingresses != nil && ingressNetworkingV1 != nil {
+					_, err := kube.Cache.Ingresses.Set(ctx, *ingressNetworkingV1)
+					if err != nil {
+						return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
+					}
+				}
+				if result == nil {
+					result = ingressNetworkingV1
+				}
+			} else if !paasErrors.IsNotFound(err) {
+				logger.ErrorC(ctx, "Error to get ingress before update: %+v", err)
+				return nil, err
+			}
+		} else {
+			originalIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Get(ctx, route.Name, v1.GetOptions{})
+			if err == nil {
+				ingressExists = true
+				ingressToUpdate := route.ToIngress()
+				ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
+				kube.modifyIngressClassForBG2(ingressToUpdate)
+
+				if kube.shouldIgnoreIngressForConverter() {
+					if ingressToUpdate.Annotations == nil {
+						ingressToUpdate.Annotations = make(map[string]string)
+					}
+					ingressToUpdate.Annotations["gateway-api-converter.netcracker.com/ignore"] = "true"
+				}
+
+				updatedIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
+				if err != nil {
+					logger.ErrorC(ctx, "Error to update ingress: %+v", err)
+					return nil, err
+				}
+				logger.InfoC(ctx, "Ingress updated: %s", route.Name)
+
+				routeFromIngress := entity.RouteFromIngress(updatedIngress)
+				if kube.Cache.Ingresses != nil && routeFromIngress != nil {
+					_, err := kube.Cache.Ingresses.Set(ctx, *routeFromIngress)
+					if err != nil {
+						return nil, fmt.Errorf("faield to place ingress into cache: %w", err)
+					}
+				}
+				if result == nil {
+					result = routeFromIngress
+				}
+			} else if !paasErrors.IsNotFound(err) {
+				logger.ErrorC(ctx, "Error to get ingress before update: %+v", err)
+				return nil, err
+			}
+		}
+	}
+
+	if !httpRouteExists && !ingressExists {
+		logger.WarnC(ctx, "Route %s not found. Creating new", route.Name)
+		return kube.CreateRoute(ctx, route, namespace)
+	}
+
+	return result, nil
 }
 
 func (kube *Kubernetes) GetRoute(ctx context.Context, resourceName string, namespace string) (*entity.Route, error) {
@@ -163,31 +232,46 @@ func (kube *Kubernetes) GetRoute(ctx context.Context, resourceName string, names
 }
 
 func (kube *Kubernetes) DeleteRoute(ctx context.Context, routeName string, namespace string) error {
-	if kube.UseNetworkingV1Ingress {
-		err := kube.getNetworkingV1Client().
-			Ingresses(namespace).
-			Delete(ctx, routeName, v1.DeleteOptions{})
-		if err != nil {
-			logger.ErrorC(ctx, "Error while deleting a ingress=%s from kubernetes: %+v", routeName, err)
-			return err
+	useGatewayAPI := kube.shouldUseGatewayAPI()
+	useLegacyIngress := kube.shouldCreateLegacyIngress()
+
+	var firstErr error
+
+	if useGatewayAPI {
+		err := kube.getGatewayV1Client().HTTPRoutes(namespace).Delete(ctx, routeName, v1.DeleteOptions{})
+		if err != nil && !paasErrors.IsNotFound(err) {
+			logger.ErrorC(ctx, "Error while deleting HTTPRoute=%s from kubernetes: %+v", routeName, err)
+			firstErr = err
+		} else if err == nil {
+			logger.InfoC(ctx, "HTTPRoute deleted: %s", routeName)
+			if kube.Cache.HTTPRoute != nil {
+				kube.Cache.HTTPRoute.Delete(ctx, namespace, routeName)
+			}
 		}
-		if kube.Cache.Ingresses != nil {
-			kube.Cache.Ingresses.Delete(ctx, namespace, routeName)
-		}
-		return nil
-	} else {
-		err := kube.getExtensionsV1Client().
-			Ingresses(namespace).
-			Delete(ctx, routeName, v1.DeleteOptions{})
-		if err != nil {
-			logger.ErrorC(ctx, "Error while deleting a ingress=%s from kubernetes: %+v", routeName, err)
-			return err
-		}
-		if kube.Cache.Ingresses != nil {
-			kube.Cache.Ingresses.Delete(ctx, namespace, routeName)
-		}
-		return nil
 	}
+
+	if useLegacyIngress {
+		var err error
+		if kube.UseNetworkingV1Ingress {
+			err = kube.getNetworkingV1Client().Ingresses(namespace).Delete(ctx, routeName, v1.DeleteOptions{})
+		} else {
+			err = kube.getExtensionsV1Client().Ingresses(namespace).Delete(ctx, routeName, v1.DeleteOptions{})
+		}
+
+		if err != nil && !paasErrors.IsNotFound(err) {
+			logger.ErrorC(ctx, "Error while deleting ingress=%s from kubernetes: %+v", routeName, err)
+			if firstErr == nil {
+				firstErr = err
+			}
+		} else if err == nil {
+			logger.InfoC(ctx, "Ingress deleted: %s", routeName)
+			if kube.Cache.Ingresses != nil {
+				kube.Cache.Ingresses.Delete(ctx, namespace, routeName)
+			}
+		}
+	}
+
+	return firstErr
 }
 
 func (kube *Kubernetes) GetRouteList(ctx context.Context, namespace string, filter filter.Meta) ([]entity.Route, error) {

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -39,8 +39,16 @@ const (
 )
 
 const (
-	partialRouteCreateMsg = "HTTPRoute route was created, Ingress route was not created - try using Update endpoint"
+	dualModeRouteUpdateHint = " - try using Update endpoint"
+	routeStatusCreated      = "created"
+	routeStatusUpdated      = "updated"
 )
+
+type routeResourceResult struct {
+	route  *entity.Route
+	status string
+	err    error
+}
 
 func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
 	if !kube.GatewaySystem.IsRouteCreationAllowed() {
@@ -50,30 +58,103 @@ func (kube *Kubernetes) CreateRoute(ctx context.Context, route *entity.Route, na
 	useGatewayAPI := kube.GatewaySystem.IsGatewayAPIEnabled()
 	useLegacyIngress := kube.GatewaySystem.IsIngressEnabled()
 
-	var httpRouteResult *entity.Route
+	var httpRouteRes, ingressRes routeResourceResult
 
 	if useGatewayAPI {
-		var err error
-		httpRouteResult, err = kube.createHTTPRoute(ctx, route, namespace)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create HTTPRoute: %w", err)
+		routeResult, err := kube.createHTTPRoute(ctx, route, namespace)
+		httpRouteRes = routeResourceResult{route: routeResult, status: routeStatusCreated, err: err}
+		if err == nil {
+			logger.InfoC(ctx, "HTTPRoute created: %s", route.Name)
 		}
-		logger.InfoC(ctx, "HTTPRoute created: %s", route.Name)
 	}
 
 	if useLegacyIngress {
-		ingressResult, ingressErr := kube.createRouteLegacyIngress(ctx, route, namespace)
-		if ingressErr != nil {
-			if useGatewayAPI {
-				return nil, paasErrors.NewInternalError(fmt.Errorf(partialRouteCreateMsg))
-			}
-			return nil, ingressErr
+		routeResult, err := kube.createRouteLegacyIngress(ctx, route, namespace)
+		ingressRes = routeResourceResult{route: routeResult, status: routeStatusCreated, err: err}
+		if err == nil {
+			logger.InfoC(ctx, "Ingress created: %s", route.Name)
 		}
-		logger.InfoC(ctx, "Ingress created: %s", route.Name)
-		return ingressResult, nil
 	}
 
-	return httpRouteResult, nil
+	return resolveRouteResult(useGatewayAPI, useLegacyIngress, httpRouteRes, ingressRes)
+}
+
+func resolveRouteResult(
+	useGatewayAPI, useLegacyIngress bool,
+	httpRouteRes, ingressRes routeResourceResult,
+) (*entity.Route, error) {
+	if useGatewayAPI && useLegacyIngress {
+		if httpRouteRes.err == nil && ingressRes.err == nil {
+			return finishRouteOperation(pickDualModeRouteResult(ingressRes, httpRouteRes), formatDualModeRouteStatus(httpRouteRes, ingressRes))
+		}
+
+		status := formatDualModeRouteStatus(httpRouteRes, ingressRes)
+		if httpRouteRes.err == nil || ingressRes.err == nil {
+			return nil, paasErrors.NewInternalError(fmt.Errorf("%s%s", status, dualModeRouteUpdateHint))
+		}
+
+		return nil, paasErrors.NewInternalError(fmt.Errorf("%s", status))
+	}
+
+	if useGatewayAPI {
+		if httpRouteRes.err != nil {
+			return nil, fmt.Errorf("httproute: error: %w", httpRouteRes.err)
+		}
+		return finishRouteOperation(httpRouteRes.route, formatRouteResourceStatus("httproute", httpRouteRes))
+	}
+
+	if ingressRes.err != nil {
+		return nil, ingressRes.err
+	}
+	return finishRouteOperation(ingressRes.route, formatRouteResourceStatus("ingress", ingressRes))
+}
+
+func finishRouteOperation(route *entity.Route, status string) (*entity.Route, error) {
+	logger.Info("Route operation completed: %s", status)
+	return route, nil
+}
+
+func pickDualModeRouteResult(ingressRes, httpRouteRes routeResourceResult) *entity.Route {
+	if ingressRes.route != nil {
+		return ingressRes.route
+	}
+	return httpRouteRes.route
+}
+
+func formatDualModeRouteStatus(httpRouteRes, ingressRes routeResourceResult) string {
+	return fmt.Sprintf("%s, %s",
+		formatRouteResourceStatus("httproute", httpRouteRes),
+		formatRouteResourceStatus("ingress", ingressRes),
+	)
+}
+
+func formatRouteResourceStatus(name string, res routeResourceResult) string {
+	if res.err != nil {
+		return fmt.Sprintf("%s: error: %v", name, res.err)
+	}
+	return fmt.Sprintf("%s: %s", name, res.status)
+}
+
+func isDeleteFailure(err error) bool {
+	return err != nil && !paasErrors.IsNotFound(err)
+}
+
+func formatDualModeDeleteRouteStatus(httpRouteErr, ingressErr error) string {
+	return fmt.Sprintf("%s, %s",
+		routeResourceDeleteStatus("httproute", httpRouteErr),
+		routeResourceDeleteStatus("ingress", ingressErr),
+	)
+}
+
+func routeResourceDeleteStatus(name string, err error) string {
+	switch {
+	case err == nil:
+		return name + ": deleted"
+	case paasErrors.IsNotFound(err):
+		return name + ": not found"
+	default:
+		return fmt.Sprintf("%s: error: %v", name, err)
+	}
 }
 
 func (kube *Kubernetes) createRouteLegacyIngress(ctx context.Context, route *entity.Route, namespace string) (*entity.Route, error) {
@@ -133,120 +214,128 @@ func (kube *Kubernetes) UpdateOrCreateRoute(ctx context.Context, route *entity.R
 	useGatewayAPI := kube.GatewaySystem.IsGatewayAPIEnabled()
 	useLegacyIngress := kube.GatewaySystem.IsIngressEnabled()
 
-	var result *entity.Route
-	var httpRouteExists bool
-	var ingressExists bool
+	var httpRouteRes, ingressRes routeResourceResult
 
 	if useGatewayAPI {
-		originalHTTPRoute, err := kube.getGatewayV1Client().HTTPRoutes(namespace).Get(ctx, route.Name, v1.GetOptions{})
-		if err != nil {
-			if paasErrors.IsNotFound(err) {
-				logger.WarnC(ctx, "HTTPRoute %s not found. Creating new", route.Name)
-				return kube.CreateRoute(ctx, route, namespace)
-			}
-			logger.ErrorC(ctx, "Error to get HTTPRoute before update: %+v", err)
-			return nil, err
-		}
-		httpRouteExists = true
-		httpRouteToUpdate := route.ToHTTPRoute(kube.GatewaySystem.Namespace, kube.GatewaySystem.Name)
-		httpRouteToUpdate.ResourceVersion = originalHTTPRoute.ResourceVersion
-
-		updatedHTTPRoute, err := kube.getGatewayV1Client().HTTPRoutes(namespace).Update(ctx, httpRouteToUpdate, v1.UpdateOptions{})
-		if err != nil {
-			logger.ErrorC(ctx, "Error to update HTTPRoute: %+v", err)
-			return nil, err
-		}
-		logger.InfoC(ctx, "HTTPRoute updated: %s", route.Name)
-
-		routeFromHTTPRoute := entity.RouteFromHTTPRoute(updatedHTTPRoute)
-		if kube.Cache.HTTPRoute != nil && routeFromHTTPRoute != nil {
-			httpRouteEntity := entity.WrapHTTPRoute(updatedHTTPRoute)
-			_, err := kube.Cache.HTTPRoute.Set(ctx, *httpRouteEntity)
-			if err != nil {
-				return nil, fmt.Errorf("failed to place HTTPRoute into cache: %w", err)
-			}
-		}
-		result = routeFromHTTPRoute
+		httpRouteRes = kube.upsertHTTPRoute(ctx, route, namespace)
 	}
 
 	if useLegacyIngress {
-		if kube.UseNetworkingV1Ingress {
-			originalIngress, err := kube.getNetworkingV1Client().Ingresses(namespace).Get(ctx, route.Name, v1.GetOptions{})
-			if err != nil {
-				if paasErrors.IsNotFound(err) {
-					logger.WarnC(ctx, "Ingress %s not found. Creating new", route.Name)
-					return kube.CreateRoute(ctx, route, namespace)
-				}
-				logger.ErrorC(ctx, "Error to get ingress before update: %+v", err)
-				return nil, err
-			}
+		ingressRes = kube.upsertLegacyIngress(ctx, route, namespace)
+	}
 
-			ingressExists = true
-			ingressToUpdate := route.ToIngressNetworkingV1()
-			ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
-			if className := ingressToUpdate.Spec.IngressClassName; className == nil || *className == "" {
-				ingressToUpdate.Spec.IngressClassName = originalIngress.Spec.IngressClassName
-			}
-			kube.configureIngress(ingressToUpdate)
+	return resolveRouteResult(useGatewayAPI, useLegacyIngress, httpRouteRes, ingressRes)
+}
 
-			updatedIngress, err := kube.getNetworkingV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
-			if err != nil {
-				logger.ErrorC(ctx, "Error to update ingress: %+v", err)
-				return nil, err
+func (kube *Kubernetes) upsertHTTPRoute(ctx context.Context, route *entity.Route, namespace string) routeResourceResult {
+	originalHTTPRoute, err := kube.getGatewayV1Client().HTTPRoutes(namespace).Get(ctx, route.Name, v1.GetOptions{})
+	if err != nil {
+		if paasErrors.IsNotFound(err) {
+			logger.WarnC(ctx, "HTTPRoute %s not found. Creating new", route.Name)
+			createdHTTPRoute, createErr := kube.createHTTPRoute(ctx, route, namespace)
+			if createErr == nil {
+				logger.InfoC(ctx, "HTTPRoute created: %s", route.Name)
 			}
-			logger.InfoC(ctx, "Ingress updated: %s", route.Name)
+			return routeResourceResult{route: createdHTTPRoute, status: routeStatusCreated, err: createErr}
+		}
+		logger.ErrorC(ctx, "Error to get HTTPRoute before update: %+v", err)
+		return routeResourceResult{err: err}
+	}
 
-			ingressNetworkingV1 := entity.RouteFromIngressNetworkingV1(updatedIngress)
-			if kube.Cache.Ingresses != nil && ingressNetworkingV1 != nil {
-				_, err := kube.Cache.Ingresses.Set(ctx, *ingressNetworkingV1)
-				if err != nil {
-					return nil, fmt.Errorf(errPlaceIngressIntoCache, err)
-				}
-			}
-			if result == nil {
-				result = ingressNetworkingV1
-			}
-		} else {
-			originalIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Get(ctx, route.Name, v1.GetOptions{})
-			if err != nil {
-				if paasErrors.IsNotFound(err) {
-					logger.WarnC(ctx, "Ingress %s not found. Creating new", route.Name)
-					return kube.CreateRoute(ctx, route, namespace)
-				}
-				logger.ErrorC(ctx, "Error to get ingress before update: %+v", err)
-				return nil, err
-			}
-			ingressExists = true
-			ingressToUpdate := route.ToIngress()
-			ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
-			kube.configureIngress(ingressToUpdate)
+	httpRouteToUpdate := route.ToHTTPRoute(kube.GatewaySystem.Namespace, kube.GatewaySystem.Name)
+	httpRouteToUpdate.ResourceVersion = originalHTTPRoute.ResourceVersion
 
-			updatedIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
-			if err != nil {
-				logger.ErrorC(ctx, "Error to update ingress: %+v", err)
-				return nil, err
-			}
-			logger.InfoC(ctx, "Ingress updated: %s", route.Name)
+	updatedHTTPRoute, err := kube.getGatewayV1Client().HTTPRoutes(namespace).Update(ctx, httpRouteToUpdate, v1.UpdateOptions{})
+	if err != nil {
+		logger.ErrorC(ctx, "Error to update HTTPRoute: %+v", err)
+		return routeResourceResult{err: err}
+	}
+	logger.InfoC(ctx, "HTTPRoute updated: %s", route.Name)
 
-			routeFromIngress := entity.RouteFromIngress(updatedIngress)
-			if kube.Cache.Ingresses != nil && routeFromIngress != nil {
-				_, err := kube.Cache.Ingresses.Set(ctx, *routeFromIngress)
-				if err != nil {
-					return nil, fmt.Errorf(errPlaceIngressIntoCache, err)
-				}
-			}
-			if result == nil {
-				result = routeFromIngress
-			}
+	routeFromHTTPRoute := entity.RouteFromHTTPRoute(updatedHTTPRoute)
+	if kube.Cache.HTTPRoute != nil && routeFromHTTPRoute != nil {
+		httpRouteEntity := entity.WrapHTTPRoute(updatedHTTPRoute)
+		if _, err := kube.Cache.HTTPRoute.Set(ctx, *httpRouteEntity); err != nil {
+			return routeResourceResult{err: fmt.Errorf("failed to place HTTPRoute into cache: %w", err)}
 		}
 	}
+	return routeResourceResult{route: routeFromHTTPRoute, status: routeStatusUpdated}
+}
 
-	if !httpRouteExists && !ingressExists {
-		logger.WarnC(ctx, "Route %s not found. Creating new", route.Name)
-		return kube.CreateRoute(ctx, route, namespace)
+func (kube *Kubernetes) upsertLegacyIngress(ctx context.Context, route *entity.Route, namespace string) routeResourceResult {
+	if kube.UseNetworkingV1Ingress {
+		return kube.upsertNetworkingV1Ingress(ctx, route, namespace)
+	}
+	return kube.upsertExtensionsV1Ingress(ctx, route, namespace)
+}
+
+func (kube *Kubernetes) upsertNetworkingV1Ingress(ctx context.Context, route *entity.Route, namespace string) routeResourceResult {
+	originalIngress, err := kube.getNetworkingV1Client().Ingresses(namespace).Get(ctx, route.Name, v1.GetOptions{})
+	if err != nil {
+		if paasErrors.IsNotFound(err) {
+			logger.WarnC(ctx, "Ingress %s not found. Creating new", route.Name)
+			ingressResult, createErr := kube.createRouteLegacyIngress(ctx, route, namespace)
+			if createErr == nil {
+				logger.InfoC(ctx, "Ingress created: %s", route.Name)
+			}
+			return routeResourceResult{route: ingressResult, status: routeStatusCreated, err: createErr}
+		}
+		logger.ErrorC(ctx, "Error to get ingress before update: %+v", err)
+		return routeResourceResult{err: err}
 	}
 
-	return result, nil
+	ingressToUpdate := route.ToIngressNetworkingV1()
+	ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
+	if className := ingressToUpdate.Spec.IngressClassName; className == nil || *className == "" {
+		ingressToUpdate.Spec.IngressClassName = originalIngress.Spec.IngressClassName
+	}
+	kube.configureIngress(ingressToUpdate)
+
+	updatedIngress, err := kube.getNetworkingV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
+	if err != nil {
+		logger.ErrorC(ctx, "Error to update ingress: %+v", err)
+		return routeResourceResult{err: err}
+	}
+	logger.InfoC(ctx, "Ingress updated: %s", route.Name)
+
+	ingressNetworkingV1 := entity.RouteFromIngressNetworkingV1(updatedIngress)
+	if err := kube.cacheIngressRoute(ctx, ingressNetworkingV1); err != nil {
+		return routeResourceResult{err: err}
+	}
+	return routeResourceResult{route: ingressNetworkingV1, status: routeStatusUpdated}
+}
+
+func (kube *Kubernetes) upsertExtensionsV1Ingress(ctx context.Context, route *entity.Route, namespace string) routeResourceResult {
+	originalIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Get(ctx, route.Name, v1.GetOptions{})
+	if err != nil {
+		if paasErrors.IsNotFound(err) {
+			logger.WarnC(ctx, "Ingress %s not found. Creating new", route.Name)
+			ingressResult, createErr := kube.createRouteLegacyIngress(ctx, route, namespace)
+			if createErr == nil {
+				logger.InfoC(ctx, "Ingress created: %s", route.Name)
+			}
+			return routeResourceResult{route: ingressResult, status: routeStatusCreated, err: createErr}
+		}
+		logger.ErrorC(ctx, "Error to get ingress before update: %+v", err)
+		return routeResourceResult{err: err}
+	}
+
+	ingressToUpdate := route.ToIngress()
+	ingressToUpdate.ResourceVersion = originalIngress.ResourceVersion
+	kube.configureIngress(ingressToUpdate)
+
+	updatedIngress, err := kube.getExtensionsV1Client().Ingresses(namespace).Update(ctx, ingressToUpdate, v1.UpdateOptions{})
+	if err != nil {
+		logger.ErrorC(ctx, "Error to update ingress: %+v", err)
+		return routeResourceResult{err: err}
+	}
+	logger.InfoC(ctx, "Ingress updated: %s", route.Name)
+
+	routeFromIngress := entity.RouteFromIngress(updatedIngress)
+	if err := kube.cacheIngressRoute(ctx, routeFromIngress); err != nil {
+		return routeResourceResult{err: err}
+	}
+	return routeResourceResult{route: routeFromIngress, status: routeStatusUpdated}
 }
 
 func (kube *Kubernetes) GetRoute(ctx context.Context, resourceName string, namespace string) (*entity.Route, error) {
@@ -260,28 +349,74 @@ func (kube *Kubernetes) GetRoute(ctx context.Context, resourceName string, names
 }
 
 func (kube *Kubernetes) DeleteRoute(ctx context.Context, routeName, namespace string) error {
-	var (
-		httpRouteErr       error
-		httpRouteAttempted bool
-	)
+	useGatewayAPI := kube.GatewaySystem.IsGatewayAPIEnabled()
+	useLegacyIngress := kube.GatewaySystem.IsIngressEnabled()
 
-	if kube.GatewaySystem.IsGatewayAPIEnabled() {
-		httpRouteAttempted = true
+	var httpRouteErr error
+	var ingressErr error
+
+	if useGatewayAPI {
 		httpRouteErr = kube.deleteRouteHTTPRoute(ctx, routeName, namespace)
-		if httpRouteErr != nil && !paasErrors.IsNotFound(httpRouteErr) {
-			return httpRouteErr
-		}
 	}
 
-	if kube.GatewaySystem.IsIngressEnabled() {
-		ingressErr := kube.deleteRouteLegacyIngress(ctx, routeName, namespace)
-		if ingressErr != nil && paasErrors.IsNotFound(ingressErr) && httpRouteAttempted && httpRouteErr == nil {
-			return nil
-		}
-		return ingressErr
+	if useLegacyIngress {
+		ingressErr = kube.deleteRouteLegacyIngress(ctx, routeName, namespace)
 	}
 
-	return httpRouteErr
+	return resolveDeleteRouteResult(useGatewayAPI, useLegacyIngress, routeName, httpRouteErr, ingressErr)
+}
+
+func resolveDeleteRouteResult(
+	useGatewayAPI, useLegacyIngress bool,
+	routeName string,
+	httpRouteErr, ingressErr error,
+) error {
+	if useGatewayAPI && useLegacyIngress {
+		status := formatDualModeDeleteRouteStatus(httpRouteErr, ingressErr)
+
+		if paasErrors.IsNotFound(httpRouteErr) && paasErrors.IsNotFound(ingressErr) {
+			logger.Warn("Route delete failed: %s", status)
+			return newRouteDeleteNotFoundError(routeName, status)
+		}
+
+		if isDeleteFailure(httpRouteErr) || isDeleteFailure(ingressErr) {
+			logger.Error("Route delete failed: %s", status)
+			return paasErrors.NewInternalError(fmt.Errorf("%s", status))
+		}
+
+		logger.Info("Route delete completed: %s", status)
+		return nil
+	}
+
+	if useGatewayAPI {
+		return resolveSingleResourceDeleteResult("httproute", httpRouteErr)
+	}
+
+	if useLegacyIngress {
+		return resolveSingleResourceDeleteResult("ingress", ingressErr)
+	}
+
+	return nil
+}
+
+func resolveSingleResourceDeleteResult(resourceName string, err error) error {
+	status := routeResourceDeleteStatus(resourceName, err)
+	if err == nil {
+		logger.Info("Route delete completed: %s", status)
+		return nil
+	}
+	if isDeleteFailure(err) {
+		logger.Error("Route delete failed: %s", status)
+		return paasErrors.NewInternalError(fmt.Errorf("%s", status))
+	}
+	logger.Warn("Route delete failed: %s", status)
+	return err
+}
+
+func newRouteDeleteNotFoundError(routeName, status string) error {
+	notFound := paasErrors.NewNotFound(schema.GroupResource{Resource: "routes"}, routeName)
+	notFound.ErrStatus.Message = status
+	return notFound
 }
 
 func (kube *Kubernetes) deleteRouteHTTPRoute(ctx context.Context, routeName, namespace string) error {

--- a/service/internal/kubernetes/route_test.go
+++ b/service/internal/kubernetes/route_test.go
@@ -900,7 +900,7 @@ func Test_CreateRoute_NetworkingV1_IngressCacheSetError(t *testing.T) {
 
 	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
 	assertions.Error(err)
-	assertions.Contains(err.Error(), "faield to place ingress into cache")
+	assertions.Contains(err.Error(), "failed to place ingress into cache")
 
 	ingressList, err := kubeClientSet.NetworkingV1().Ingresses(testNamespace1).List(ctx, metav1.ListOptions{})
 	assertions.NoError(err)
@@ -920,7 +920,7 @@ func Test_CreateRoute_V1beta1_IngressCacheSetError(t *testing.T) {
 
 	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
 	assertions.Error(err)
-	assertions.Contains(err.Error(), "faield to place ingress into cache")
+	assertions.Contains(err.Error(), "failed to place ingress into cache")
 
 	ingressList, err := kubeClientSet.ExtensionsV1beta1().Ingresses(testNamespace1).List(ctx, metav1.ListOptions{})
 	assertions.NoError(err)

--- a/service/internal/kubernetes/route_test.go
+++ b/service/internal/kubernetes/route_test.go
@@ -522,7 +522,9 @@ func Test_CreateRoute_DualMode_HTTPRouteCreated_IngressFailed_ReturnsPartialCrea
 	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
 	assertions.Error(err)
 	assertions.True(paasErrors.IsInternalError(err))
-	assertions.Contains(err.Error(), "HTTPRoute route was created, Ingress route was not created - try using Update endpoint")
+	assertions.Contains(err.Error(), "httproute: created")
+	assertions.Contains(err.Error(), "ingress: error:")
+	assertions.Contains(err.Error(), "try using Update endpoint")
 
 	httpRouteList, err := gwClient.GatewayV1().HTTPRoutes(testNamespace1).List(ctx, metav1.ListOptions{})
 	assertions.NoError(err)
@@ -533,7 +535,40 @@ func Test_CreateRoute_DualMode_HTTPRouteCreated_IngressFailed_ReturnsPartialCrea
 	assertions.Empty(ingressList.Items)
 }
 
-func Test_CreateRoute_DualMode_HTTPRouteFailed_IngressNotCreated(t *testing.T) {
+func Test_CreateRoute_DualMode_BothFailed_ReturnsFullStatusError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	gwClient := gatewayclientfake.NewSimpleClientset()
+	gwClient.PrependReactor("create", "httproutes", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewInternalError(fmt.Errorf("httproute create failed"))
+	})
+	kubeClientSet := fake.NewClientset()
+	kubeClientSet.PrependReactor("create", "ingresses", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewInternalError(fmt.Errorf("ingress create failed"))
+	})
+	kubeClient, err := NewKubernetesClientBuilder().
+		WithNamespace(testNamespace1).
+		WithClient(&backend.KubernetesApi{
+			KubernetesInterface:  kubeClientSet,
+			CertmanagerInterface: &certClient.Clientset{},
+			GatewayInterface:     gwClient,
+		}).
+		WithGatewaySystemType(LegacyIngress + "," + GatewayApiDefault).
+		Build()
+	require.NoError(t, err)
+	kubeClient.UseNetworkingV1Ingress = true
+
+	_, err = kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.Error(err)
+	assertions.True(paasErrors.IsInternalError(err))
+	assertions.Contains(err.Error(), "httproute: error:")
+	assertions.Contains(err.Error(), "httproute create failed")
+	assertions.Contains(err.Error(), "ingress: error:")
+	assertions.Contains(err.Error(), "ingress create failed")
+	assertions.NotContains(err.Error(), "try using Update endpoint")
+}
+
+func Test_CreateRoute_DualMode_HTTPRouteFailed_IngressCreated_ReturnsPartialCreateError(t *testing.T) {
 	assertions := require.New(t)
 	ctx := context.Background()
 	gwClient := gatewayclientfake.NewSimpleClientset()
@@ -555,12 +590,14 @@ func Test_CreateRoute_DualMode_HTTPRouteFailed_IngressNotCreated(t *testing.T) {
 
 	_, err = kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
 	assertions.Error(err)
-	assertions.Contains(err.Error(), "failed to create HTTPRoute")
-	assertions.NotContains(err.Error(), "try using Update endpoint")
+	assertions.True(paasErrors.IsInternalError(err))
+	assertions.Contains(err.Error(), "httproute: error:")
+	assertions.Contains(err.Error(), "ingress: created")
+	assertions.Contains(err.Error(), "try using Update endpoint")
 
 	ingressList, err := kubeClientSet.NetworkingV1().Ingresses(testNamespace1).List(ctx, metav1.ListOptions{})
 	assertions.NoError(err)
-	assertions.Empty(ingressList.Items)
+	assertions.Len(ingressList.Items, 1)
 }
 
 func Test_CreateRoute_DualMode_CreatesHTTPRouteAndIngress(t *testing.T) {
@@ -581,6 +618,86 @@ func Test_CreateRoute_DualMode_CreatesHTTPRouteAndIngress(t *testing.T) {
 	assertions.NoError(err)
 	assertions.Len(ingressList.Items, 1)
 	assertions.Equal("true", ingressList.Items[0].Annotations[IgnoreApiConverterAnnotation])
+}
+
+func Test_UpdateOrCreateRoute_DualMode_AfterPartialCreate_CreatesMissingIngress(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, k8sClient, gwClient := newDualModeKubeClient(t)
+
+	var ingressCreateAttempts int
+	k8sClient.PrependReactor("create", "ingresses", func(action kube_test.Action) (bool, runtime.Object, error) {
+		ingressCreateAttempts++
+		if ingressCreateAttempts == 1 {
+			return true, nil, paasErrors.NewInternalError(fmt.Errorf("ingress create failed"))
+		}
+		return false, nil, nil
+	})
+	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.Error(err)
+	assertions.Contains(err.Error(), "httproute: created")
+	assertions.Contains(err.Error(), "ingress: error:")
+
+	httpRouteList, err := gwClient.GatewayV1().HTTPRoutes(testNamespace1).List(ctx, metav1.ListOptions{})
+	assertions.NoError(err)
+	assertions.Len(httpRouteList.Items, 1)
+
+	updated, err := kubeClient.UpdateOrCreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.NoError(err)
+	assertions.NotNil(updated)
+
+	ingressList, err := k8sClient.NetworkingV1().Ingresses(testNamespace1).List(ctx, metav1.ListOptions{})
+	assertions.NoError(err)
+	assertions.Len(ingressList.Items, 1)
+}
+
+func Test_UpdateOrCreateRoute_DualMode_HTTPRouteExists_CreatesMissingIngress(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, k8sClient, gwClient := newDualModeKubeClient(t)
+
+	route := dualModeTestRoute()
+	httpRoute := route.ToHTTPRoute(kubeClient.GatewaySystem.Namespace, kubeClient.GatewaySystem.Name)
+	_, err := gwClient.GatewayV1().HTTPRoutes(testNamespace1).Create(ctx, httpRoute, metav1.CreateOptions{})
+	assertions.NoError(err)
+
+	updated, err := kubeClient.UpdateOrCreateRoute(ctx, route, testNamespace1)
+	assertions.NoError(err)
+	assertions.NotNil(updated)
+
+	ingressList, err := k8sClient.NetworkingV1().Ingresses(testNamespace1).List(ctx, metav1.ListOptions{})
+	assertions.NoError(err)
+	assertions.Len(ingressList.Items, 1)
+	assertions.Equal("true", ingressList.Items[0].Annotations[IgnoreApiConverterAnnotation])
+}
+
+func Test_UpdateOrCreateRoute_DualMode_HTTPRouteUpdated_IngressUpdateError_ReturnsFullStatusError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, k8sClient, gwClient := newDualModeKubeClient(t)
+
+	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.NoError(err)
+
+	k8sClient.PrependReactor("update", "ingresses", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewInternalError(fmt.Errorf("ingress update failed"))
+	})
+
+	_, err = kubeClient.UpdateOrCreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.Error(err)
+	assertions.True(paasErrors.IsInternalError(err))
+	assertions.Contains(err.Error(), "httproute: updated")
+	assertions.Contains(err.Error(), "ingress: error:")
+	assertions.Contains(err.Error(), "ingress update failed")
+	assertions.Contains(err.Error(), "try using Update endpoint")
+
+	httpRouteList, err := gwClient.GatewayV1().HTTPRoutes(testNamespace1).List(ctx, metav1.ListOptions{})
+	assertions.NoError(err)
+	assertions.Len(httpRouteList.Items, 1)
+
+	ingressList, err := k8sClient.NetworkingV1().Ingresses(testNamespace1).List(ctx, metav1.ListOptions{})
+	assertions.NoError(err)
+	assertions.Len(ingressList.Items, 1)
 }
 
 func Test_UpdateOrCreateRoute_DualMode_UpdatesBoth(t *testing.T) {
@@ -622,6 +739,87 @@ func Test_DeleteRoute_DualMode_HTTPRouteDeleted_IngressNotFound_NoError(t *testi
 
 	_, err = gwClient.GatewayV1().HTTPRoutes(testNamespace1).Get(ctx, testIngress, metav1.GetOptions{})
 	assertions.True(paasErrors.IsNotFound(err))
+}
+
+func Test_DeleteRoute_DualMode_HTTPRouteDeleted_IngressDeleteError_ReturnsFullStatusError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, k8sClient, gwClient := newDualModeKubeClient(t)
+
+	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.NoError(err)
+
+	k8sClient.PrependReactor("delete", "ingresses", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewInternalError(fmt.Errorf("ingress delete failed"))
+	})
+
+	err = kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
+	assertions.Error(err)
+	assertions.True(paasErrors.IsInternalError(err))
+	assertions.Contains(err.Error(), "httproute: deleted")
+	assertions.Contains(err.Error(), "ingress: error:")
+	assertions.Contains(err.Error(), "ingress delete failed")
+
+	_, err = gwClient.GatewayV1().HTTPRoutes(testNamespace1).Get(ctx, testIngress, metav1.GetOptions{})
+	assertions.True(paasErrors.IsNotFound(err))
+}
+
+func Test_DeleteRoute_DualMode_HTTPRouteDeleteError_IngressDeleted_ReturnsFullStatusError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, k8sClient, gwClient := newDualModeKubeClient(t)
+
+	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.NoError(err)
+
+	gwClient.PrependReactor("delete", "httproutes", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewInternalError(fmt.Errorf("httproute delete failed"))
+	})
+
+	err = kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
+	assertions.Error(err)
+	assertions.True(paasErrors.IsInternalError(err))
+	assertions.Contains(err.Error(), "httproute: error:")
+	assertions.Contains(err.Error(), "httproute delete failed")
+	assertions.Contains(err.Error(), "ingress: deleted")
+
+	_, err = k8sClient.NetworkingV1().Ingresses(testNamespace1).Get(ctx, testIngress, metav1.GetOptions{})
+	assertions.True(paasErrors.IsNotFound(err))
+}
+
+func Test_DeleteRoute_DualMode_BothDeleteFailed_ReturnsFullStatusError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, k8sClient, gwClient := newDualModeKubeClient(t)
+
+	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.NoError(err)
+
+	gwClient.PrependReactor("delete", "httproutes", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewInternalError(fmt.Errorf("httproute delete failed"))
+	})
+	k8sClient.PrependReactor("delete", "ingresses", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewInternalError(fmt.Errorf("ingress delete failed"))
+	})
+
+	err = kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
+	assertions.Error(err)
+	assertions.True(paasErrors.IsInternalError(err))
+	assertions.Contains(err.Error(), "httproute: error:")
+	assertions.Contains(err.Error(), "httproute delete failed")
+	assertions.Contains(err.Error(), "ingress: error:")
+	assertions.Contains(err.Error(), "ingress delete failed")
+}
+
+func Test_DeleteRoute_DualMode_BothNotFound_ReturnsNotFound(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, _, _ := newDualModeKubeClient(t)
+
+	err := kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
+	assertions.True(paasErrors.IsNotFound(err))
+	assertions.Contains(err.Error(), "httproute: not found")
+	assertions.Contains(err.Error(), "ingress: not found")
 }
 
 func Test_DeleteRoute_DualMode_DeletesBoth(t *testing.T) {
@@ -846,7 +1044,8 @@ func Test_CreateRoute_GatewayAPIOnly_HTTPRouteCreateError(t *testing.T) {
 
 	_, err = kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
 	assertions.Error(err)
-	assertions.Contains(err.Error(), "failed to create HTTPRoute")
+	assertions.Contains(err.Error(), "httproute: error:")
+	assertions.Contains(err.Error(), "httproute create failed")
 }
 
 func Test_CreateRoute_NetworkingV1_IngressCreateError(t *testing.T) {

--- a/service/internal/kubernetes/route_test.go
+++ b/service/internal/kubernetes/route_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
 	"testing"
 
 	certClient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
@@ -605,72 +604,6 @@ func Test_CreateRoute_LegacyIngressOnly_NoIgnoreAnnotation(t *testing.T) {
 	assertions.Empty(ingressList.Items[0].Annotations[IgnoreApiConverterAnnotation])
 }
 
-func Test_ValidateAnnotationsForGatewayAPI_BackendProtocol(t *testing.T) {
-	assertions := require.New(t)
-	ctx := context.Background()
-
-	routeToCreate := &entity.Route{
-		Metadata: entity.Metadata{
-			Name:      testIngress,
-			Namespace: testNamespace1,
-			Annotations: map[string]string{
-				AnnotationBackendProtocol: "HTTPS",
-			},
-		},
-		Spec: entity.RouteSpec{
-			Host:    "test.example.com",
-			Service: entity.Target{Name: "test-service"},
-			Port:    entity.RoutePort{TargetPort: 8080},
-		},
-	}
-
-	kubeClientSet := fake.NewClientset()
-	certClientSet := &certClient.Clientset{}
-	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: certClientSet})
-	kubeClient.GatewaySystem.Type = GatewayApiDefault
-
-	_, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
-	assertions.NotNil(err)
-	assertions.True(paasErrors.IsInvalid(err))
-	var statusErr *paasErrors.StatusError
-	assertions.ErrorAs(err, &statusErr)
-	assertions.Equal(http.StatusUnprocessableEntity, int(statusErr.Status().Code))
-	assertions.Contains(statusErr.Status().Message, "backend-protocol")
-}
-
-func Test_ValidateAnnotationsForGatewayAPI_SSLPassthrough(t *testing.T) {
-	assertions := require.New(t)
-	ctx := context.Background()
-
-	routeToCreate := &entity.Route{
-		Metadata: entity.Metadata{
-			Name:      testIngress,
-			Namespace: testNamespace1,
-			Annotations: map[string]string{
-				AnnotationSSLPassthrough: "true",
-			},
-		},
-		Spec: entity.RouteSpec{
-			Host:    "test.example.com",
-			Service: entity.Target{Name: "test-service"},
-			Port:    entity.RoutePort{TargetPort: 8080},
-		},
-	}
-
-	kubeClientSet := fake.NewClientset()
-	certClientSet := &certClient.Clientset{}
-	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: certClientSet})
-	kubeClient.GatewaySystem.Type = GatewayApiDefault
-
-	_, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
-	assertions.NotNil(err)
-	assertions.True(paasErrors.IsInvalid(err))
-	var statusErr *paasErrors.StatusError
-	assertions.ErrorAs(err, &statusErr)
-	assertions.Equal(http.StatusUnprocessableEntity, int(statusErr.Status().Code))
-	assertions.Contains(statusErr.Status().Message, "ssl-passthrough")
-}
-
 func Test_ValidateAnnotationsForGatewayAPI_AllowedAnnotations(t *testing.T) {
 	assertions := require.New(t)
 	ctx := context.Background()
@@ -730,6 +663,34 @@ func Test_ValidateAnnotationsForGatewayAPI_LegacyIngressAllowsCritical(t *testin
 	route, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
 	assertions.Nil(err) // No error because legacy-ingress doesn't validate
 	assertions.NotNil(route)
+}
+
+func Test_validateAnnotationsForGatewayAPI_ReferencesAllConstants(t *testing.T) {
+	assertions := require.New(t)
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{
+		KubernetesInterface:  fake.NewClientset(),
+		CertmanagerInterface: &certClient.Clientset{},
+	})
+
+	cases := map[string]string{
+		AnnotationBackendProtocol:   BackendTlsOrTrafficWarning,
+		AnnotationSecureBackends:    BackendTLSWarning,
+		AnnotationAuthType:          SecurityPolicyWarning,
+		AnnotationSSLPassthrough:    TlsRouteWarning,
+		AnnotationConfigSnippet:     ConfigSnippetWarning,
+		AnnotationUpstreamVhost:     EnvoyExtensionWarning,
+		AnnotationProxyRedirectFrom: EnvoyExtensionWarning,
+		AnnotationProxyRedirectTo:   EnvoyExtensionWarning,
+	}
+	for annotation, warning := range cases {
+		err := kubeClient.validateAnnotationsForGatewayAPI(map[string]string{annotation: "test-value"})
+		assertions.Error(err, "annotation %s", annotation)
+		assertions.True(paasErrors.IsInvalid(err))
+		var statusErr *paasErrors.StatusError
+		assertions.ErrorAs(err, &statusErr)
+		assertions.Contains(statusErr.Status().Message, warning)
+	}
+	assertions.Equal("gateway-api-converter.netcracker.com/ignore", IgnoreApiConverterAnnotation)
 }
 
 func newTinyRouteCache(t *testing.T, caches ...cache.CacheName) *cache.ResourcesCache {
@@ -921,56 +882,216 @@ func Test_CreateRoute_DualMode_V1beta1_SetsIgnoreAnnotationOnNilAnnotations(t *t
 	assertions.Equal("true", ingressList.Items[0].Annotations[IgnoreApiConverterAnnotation])
 }
 
-func Test_ValidateAnnotationsForGatewayAPI_CriticalAnnotations(t *testing.T) {
-	tests := []struct {
-		name       string
-		annotation string
-		value      string
-		message    string
-	}{
-		{"backend protocol", AnnotationBackendProtocol, "HTTPS", BackendTlsOrTrafficWarning},
-		{"secure backends", AnnotationSecureBackends, "true", BackendTLSWarning},
-		{"auth type", AnnotationAuthType, "basic", SecurityPolicyWarning},
-		{"ssl passthrough", AnnotationSSLPassthrough, "true", TlsRouteWarning},
-		{"config snippet", AnnotationConfigSnippet, "more_set_headers", ConfigSnippetWarning},
-		{"upstream vhost", AnnotationUpstreamVhost, "example.com", EnvoyExtensionWarning},
-		{"proxy redirect from", AnnotationProxyRedirectFrom, "/a", EnvoyExtensionWarning},
-		{"proxy redirect to", AnnotationProxyRedirectTo, "/b", EnvoyExtensionWarning},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assertions := require.New(t)
-			ctx := context.Background()
+func Test_UpdateOrCreateRoute_GatewayAPIOnly_HTTPRouteUpdateError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	gwClient := gatewayclientfake.NewSimpleClientset()
+	kubeClient, err := NewKubernetesClientBuilder().
+		WithNamespace(testNamespace1).
+		WithClient(&backend.KubernetesApi{
+			KubernetesInterface:  fake.NewClientset(),
+			CertmanagerInterface: &certClient.Clientset{},
+			GatewayInterface:     gwClient,
+		}).
+		WithGatewaySystemType(GatewayApiDefault).
+		Build()
+	require.NoError(t, err)
 
-			routeToCreate := &entity.Route{
-				Metadata: entity.Metadata{
-					Name:      testIngress,
-					Namespace: testNamespace1,
-					Annotations: map[string]string{
-						tt.annotation: tt.value,
-					},
-				},
-				Spec: entity.RouteSpec{
-					Host:    "test.example.com",
-					Service: entity.Target{Name: "test-service"},
-					Port:    entity.RoutePort{TargetPort: 8080},
-				},
-			}
+	route := dualModeTestRoute()
+	_, err = kubeClient.CreateRoute(ctx, route, testNamespace1)
+	assertions.NoError(err)
 
-			kubeClientSet := fake.NewClientset()
-			certClientSet := &certClient.Clientset{}
-			kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{
-				KubernetesInterface:  kubeClientSet,
-				CertmanagerInterface: certClientSet,
-			})
-			kubeClient.GatewaySystem.Type = GatewayApiDefault
+	gwClient.PrependReactor("update", "httproutes", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("httproute update failed")
+	})
 
-			_, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
-			assertions.Error(err)
-			assertions.True(paasErrors.IsInvalid(err))
-			var statusErr *paasErrors.StatusError
-			assertions.ErrorAs(err, &statusErr)
-			assertions.Contains(statusErr.Status().Message, tt.message)
-		})
-	}
+	_, err = kubeClient.UpdateOrCreateRoute(ctx, route, testNamespace1)
+	assertions.Error(err)
+	assertions.Contains(err.Error(), "httproute update failed")
+}
+
+func Test_UpdateOrCreateRoute_GatewayAPIOnly_HTTPRouteGetError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	gwClient := gatewayclientfake.NewSimpleClientset()
+	gwClient.PrependReactor("get", "httproutes", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewInternalError(fmt.Errorf("get httproute failed"))
+	})
+	kubeClient, err := NewKubernetesClientBuilder().
+		WithNamespace(testNamespace1).
+		WithClient(&backend.KubernetesApi{
+			KubernetesInterface:  fake.NewClientset(),
+			CertmanagerInterface: &certClient.Clientset{},
+			GatewayInterface:     gwClient,
+		}).
+		WithGatewaySystemType(GatewayApiDefault).
+		Build()
+	require.NoError(t, err)
+
+	_, err = kubeClient.UpdateOrCreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.Error(err)
+	assertions.Contains(err.Error(), "get httproute failed")
+}
+
+func Test_UpdateOrCreateRoute_GatewayAPIOnly_HTTPRouteCacheSetError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, _ := newGatewayAPIOnlyKubeClient(t)
+
+	route := dualModeTestRoute()
+	_, err := kubeClient.CreateRoute(ctx, route, testNamespace1)
+	assertions.NoError(err)
+
+	kubeClient.Cache = newTinyRouteCache(t, cache.HttpRouteCache)
+	route.Spec.Port.TargetPort = 7070
+
+	_, err = kubeClient.UpdateOrCreateRoute(ctx, route, testNamespace1)
+	assertions.Error(err)
+	assertions.Contains(err.Error(), "failed to place HTTPRoute into cache")
+}
+
+func Test_UpdateOrCreateRoute_GatewayAPIOnly_PlacesHTTPRouteInCache(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, _ := newGatewayAPIOnlyKubeClient(t)
+	kubeClient.Cache = cache.NewTestResourcesCache(cache.HttpRouteCache)
+
+	route := dualModeTestRoute()
+	_, err := kubeClient.CreateRoute(ctx, route, testNamespace1)
+	assertions.NoError(err)
+
+	route.Spec.Port.TargetPort = 7070
+	_, err = kubeClient.UpdateOrCreateRoute(ctx, route, testNamespace1)
+	assertions.NoError(err)
+
+	cached := kubeClient.Cache.HTTPRoute.Get(ctx, testNamespace1, testIngress)
+	assertions.NotNil(cached)
+}
+
+func Test_DeleteRoute_GatewayAPIOnly_HTTPRouteNotFound_NoError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, _ := newGatewayAPIOnlyKubeClient(t)
+
+	err := kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
+	assertions.NoError(err)
+}
+
+func Test_DeleteRoute_GatewayAPIOnly_HTTPRouteDeleteError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	gwClient := gatewayclientfake.NewSimpleClientset()
+	kubeClient, err := NewKubernetesClientBuilder().
+		WithNamespace(testNamespace1).
+		WithClient(&backend.KubernetesApi{
+			KubernetesInterface:  fake.NewClientset(),
+			CertmanagerInterface: &certClient.Clientset{},
+			GatewayInterface:     gwClient,
+		}).
+		WithGatewaySystemType(GatewayApiDefault).
+		Build()
+	require.NoError(t, err)
+
+	_, err = kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	require.NoError(t, err)
+
+	gwClient.PrependReactor("delete", "httproutes", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewInternalError(fmt.Errorf("httproute delete failed"))
+	})
+
+	err = kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
+	assertions.Error(err)
+	assertions.Contains(err.Error(), "httproute delete failed")
+}
+
+func Test_DeleteRoute_LegacyIngress_NetworkingV1_IngressNotFound_NoError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClientSet := fake.NewClientset()
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{
+		KubernetesInterface:  kubeClientSet,
+		CertmanagerInterface: &certClient.Clientset{},
+	})
+	kubeClient.UseNetworkingV1Ingress = true
+	kubeClient.GatewaySystem.Type = LegacyIngress
+
+	err := kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
+	assertions.NoError(err)
+}
+
+func Test_DeleteRoute_LegacyIngress_NetworkingV1_IngressDeleteError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClientSet := fake.NewClientset()
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{
+		KubernetesInterface:  kubeClientSet,
+		CertmanagerInterface: &certClient.Clientset{},
+	})
+	kubeClient.UseNetworkingV1Ingress = true
+	kubeClient.GatewaySystem.Type = LegacyIngress
+
+	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	require.NoError(t, err)
+
+	kubeClientSet.PrependReactor("delete", "ingresses", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewInternalError(fmt.Errorf("ingress delete failed"))
+	})
+
+	err = kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
+	assertions.Error(err)
+	assertions.Contains(err.Error(), "ingress delete failed")
+}
+
+func Test_DeleteRoute_LegacyIngress_V1beta1_IngressNotFound_NoError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClientSet := fake.NewClientset()
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{
+		KubernetesInterface:  kubeClientSet,
+		CertmanagerInterface: &certClient.Clientset{},
+	})
+	kubeClient.GatewaySystem.Type = LegacyIngress
+
+	err := kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
+	assertions.NoError(err)
+}
+
+func Test_DeleteRoute_LegacyIngress_V1beta1_IngressDeleteError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClientSet := fake.NewClientset()
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{
+		KubernetesInterface:  kubeClientSet,
+		CertmanagerInterface: &certClient.Clientset{},
+	})
+	kubeClient.GatewaySystem.Type = LegacyIngress
+
+	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	require.NoError(t, err)
+
+	kubeClientSet.PrependReactor("delete", "ingresses", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewInternalError(fmt.Errorf("extensions ingress delete failed"))
+	})
+
+	err = kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
+	assertions.Error(err)
+	assertions.Contains(err.Error(), "extensions ingress delete failed")
+}
+
+func Test_UpdateOrCreateRoute_DualMode_SetsIgnoreAnnotationOnIngressUpdate(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, k8sClient, _ := newDualModeKubeClient(t)
+
+	route := dualModeTestRoute()
+	_, err := kubeClient.CreateRoute(ctx, route, testNamespace1)
+	assertions.NoError(err)
+
+	route.Spec.Port.TargetPort = 6060
+	_, err = kubeClient.UpdateOrCreateRoute(ctx, route, testNamespace1)
+	assertions.NoError(err)
+
+	ingress, err := k8sClient.NetworkingV1().Ingresses(testNamespace1).Get(ctx, testIngress, metav1.GetOptions{})
+	assertions.NoError(err)
+	assertions.Equal("true", ingress.Annotations[IgnoreApiConverterAnnotation])
 }

--- a/service/internal/kubernetes/route_test.go
+++ b/service/internal/kubernetes/route_test.go
@@ -433,8 +433,8 @@ func Test_CreateRoute_GatewayAPIOnly_Error(t *testing.T) {
 	}
 
 	kubeClientSet := fake.NewClientset()
-	cert_client := &certClient.Clientset{}
-	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: cert_client})
+	certClientSet := &certClient.Clientset{}
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: certClientSet})
 	kubeClient.GatewaySystemType = "invalid-type"
 
 	_, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
@@ -447,8 +447,8 @@ func Test_DeleteRoute_GatewayAPIOnly_Error(t *testing.T) {
 	ctx := context.Background()
 
 	kubeClientSet := fake.NewClientset()
-	cert_client := &certClient.Clientset{}
-	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: cert_client})
+	certClientSet := &certClient.Clientset{}
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: certClientSet})
 	kubeClient.GatewaySystemType = "invalid-type"
 
 	err := kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
@@ -465,8 +465,8 @@ func Test_UpdateOrCreateRoute_GatewayAPIOnly_Error(t *testing.T) {
 	}
 
 	kubeClientSet := fake.NewClientset()
-	cert_client := &certClient.Clientset{}
-	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: cert_client})
+	certClientSet := &certClient.Clientset{}
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: certClientSet})
 	kubeClient.GatewaySystemType = "invalid-type"
 
 	_, err := kubeClient.UpdateOrCreateRoute(ctx, routeToCreate, testNamespace1)
@@ -492,8 +492,8 @@ func Test_CreateRoute_WithBothModesIgnoresIngress(t *testing.T) {
 	}
 
 	kubeClientSet := fake.NewClientset()
-	cert_client := &certClient.Clientset{}
-	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: cert_client})
+	certClientSet := &certClient.Clientset{}
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: certClientSet})
 	kubeClient.UseNetworkingV1Ingress = true
 	kubeClient.GatewaySystemType = "legacy-ingress" // Only Ingress, no Gateway API
 
@@ -501,7 +501,6 @@ func Test_CreateRoute_WithBothModesIgnoresIngress(t *testing.T) {
 	assertions.Nil(err)
 	assertions.NotNil(route)
 
-	// Verify Ingress created without ignore annotation (since only legacy-ingress mode)
 	ingressList, err := kubeClientSet.NetworkingV1().Ingresses(testNamespace1).List(ctx, metav1.ListOptions{})
 	assertions.Nil(err)
 	assertions.Equal(1, len(ingressList.Items))
@@ -528,8 +527,8 @@ func Test_ValidateAnnotationsForGatewayAPI_BackendProtocol(t *testing.T) {
 	}
 
 	kubeClientSet := fake.NewClientset()
-	cert_client := &certClient.Clientset{}
-	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: cert_client})
+	certClientSet := &certClient.Clientset{}
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: certClientSet})
 	kubeClient.GatewaySystemType = GatewayApiDefault
 
 	_, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
@@ -558,8 +557,8 @@ func Test_ValidateAnnotationsForGatewayAPI_SSLPassthrough(t *testing.T) {
 	}
 
 	kubeClientSet := fake.NewClientset()
-	cert_client := &certClient.Clientset{}
-	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: cert_client})
+	certClientSet := &certClient.Clientset{}
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: certClientSet})
 	kubeClient.GatewaySystemType = GatewayApiDefault
 
 	_, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
@@ -590,8 +589,8 @@ func Test_ValidateAnnotationsForGatewayAPI_AllowedAnnotations(t *testing.T) {
 	}
 
 	kubeClientSet := fake.NewClientset()
-	cert_client := &certClient.Clientset{}
-	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: cert_client})
+	certClientSet := &certClient.Clientset{}
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: certClientSet})
 	kubeClient.GatewaySystemType = LegacyIngress // Only Ingress mode - no validation
 
 	route, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
@@ -619,8 +618,8 @@ func Test_ValidateAnnotationsForGatewayAPI_LegacyIngressAllowsCritical(t *testin
 	}
 
 	kubeClientSet := fake.NewClientset()
-	cert_client := &certClient.Clientset{}
-	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: cert_client})
+	certClientSet := &certClient.Clientset{}
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: certClientSet})
 	kubeClient.UseNetworkingV1Ingress = true
 	kubeClient.GatewaySystemType = LegacyIngress // Only Ingress - should NOT validate
 

--- a/service/internal/kubernetes/route_test.go
+++ b/service/internal/kubernetes/route_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"testing"
 
 	certClient "github.com/cert-manager/cert-manager/pkg/client/clientset/versioned"
@@ -14,13 +15,14 @@ import (
 	"k8s.io/api/extensions/v1beta1"
 	networkingV1 "k8s.io/api/networking/v1"
 	v1 "k8s.io/api/networking/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	paasErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/kubernetes/fake"
 	kube_test "k8s.io/client-go/testing"
+	gatewayclientfake "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned/fake"
 )
 
 func getVariables() (*entity.Route, *cache.ResourcesCache) {
@@ -305,7 +307,7 @@ func Test_GetRouteFromCache_UseNetworkingV1Ingress_Success(t *testing.T) {
 	kubeClientSet := fake.NewClientset()
 	kubeClientSet.Discovery().(*fakediscovery.FakeDiscovery).FakedServerVersion = &version.Info{GitVersion: "v1.23.0"}
 	kubeClientSet.PrependReactor("get", "ingresses", func(action kube_test.Action) (handled bool, ret runtime.Object, err error) {
-		return true, nil, errors.NewInternalError(fmt.Errorf("test api server error"))
+		return true, nil, paasErrors.NewInternalError(fmt.Errorf("test api server error"))
 	})
 
 	cert_client := &certClient.Clientset{}
@@ -374,8 +376,8 @@ func Test_ShouldUseGatewayAPI(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			kube := &Kubernetes{GatewaySystemType: tt.gatewaySystemType}
-			result := kube.shouldUseGatewayAPI()
+			gs := GatewaySystem{Type: tt.gatewaySystemType}
+			result := gs.ShouldUseGatewayAPI()
 			require.Equal(t, tt.expected, result)
 		})
 	}
@@ -395,8 +397,8 @@ func Test_ShouldCreateLegacyIngress(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			kube := &Kubernetes{GatewaySystemType: tt.gatewaySystemType}
-			result := kube.shouldCreateLegacyIngress()
+			gs := GatewaySystem{Type: tt.gatewaySystemType}
+			result := gs.ShouldCreateLegacyIngress()
 			require.Equal(t, tt.expected, result)
 		})
 	}
@@ -416,8 +418,8 @@ func Test_ShouldIgnoreIngressForConverter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			kube := &Kubernetes{GatewaySystemType: tt.gatewaySystemType}
-			result := kube.shouldIgnoreIngressForConverter()
+			gs := GatewaySystem{Type: tt.gatewaySystemType}
+			result := gs.ShouldIgnoreIngressForConverter()
 			require.Equal(t, tt.expected, result)
 		})
 	}
@@ -435,24 +437,24 @@ func Test_CreateRoute_GatewayAPIOnly_Error(t *testing.T) {
 	kubeClientSet := fake.NewClientset()
 	certClientSet := &certClient.Clientset{}
 	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: certClientSet})
-	kubeClient.GatewaySystemType = "invalid-type"
+	kubeClient.GatewaySystem.Type = "invalid-type"
 
 	_, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "does not allow any Route creation")
 }
 
-func Test_DeleteRoute_GatewayAPIOnly_Error(t *testing.T) {
+func Test_DeleteRoute_InvalidType_NoOp(t *testing.T) {
 	assertions := require.New(t)
 	ctx := context.Background()
 
 	kubeClientSet := fake.NewClientset()
 	certClientSet := &certClient.Clientset{}
 	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: certClientSet})
-	kubeClient.GatewaySystemType = "invalid-type"
+	kubeClient.GatewaySystem.Type = "invalid-type"
 
 	err := kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
-	assertions.Nil(err) // DeleteRoute не возвращает ошибку, просто ничего не делает
+	assertions.Nil(err)
 }
 
 func Test_UpdateOrCreateRoute_GatewayAPIOnly_Error(t *testing.T) {
@@ -467,14 +469,109 @@ func Test_UpdateOrCreateRoute_GatewayAPIOnly_Error(t *testing.T) {
 	kubeClientSet := fake.NewClientset()
 	certClientSet := &certClient.Clientset{}
 	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: certClientSet})
-	kubeClient.GatewaySystemType = "invalid-type"
+	kubeClient.GatewaySystem.Type = "invalid-type"
 
 	_, err := kubeClient.UpdateOrCreateRoute(ctx, routeToCreate, testNamespace1)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "does not allow any Route update")
 }
 
-func Test_CreateRoute_WithBothModesIgnoresIngress(t *testing.T) {
+func dualModeTestRoute() *entity.Route {
+	return &entity.Route{
+		Metadata: entity.Metadata{
+			Name:      testIngress,
+			Namespace: testNamespace1,
+		},
+		Spec: entity.RouteSpec{
+			Host:    "test.example.com",
+			Path:    "/test",
+			Service: entity.Target{Name: "test-service"},
+			Port:    entity.RoutePort{TargetPort: 8080},
+		},
+	}
+}
+
+func newDualModeKubeClient(t *testing.T) (*Kubernetes, *fake.Clientset, *gatewayclientfake.Clientset) {
+	t.Helper()
+	kubeClientSet := fake.NewClientset()
+	gwClient := gatewayclientfake.NewSimpleClientset()
+	certClientSet := &certClient.Clientset{}
+	kubeClient, err := NewKubernetesClientBuilder().
+		WithNamespace(testNamespace1).
+		WithClient(&backend.KubernetesApi{
+			KubernetesInterface:  kubeClientSet,
+			CertmanagerInterface: certClientSet,
+			GatewayInterface:     gwClient,
+		}).
+		WithGatewaySystemType(LegacyIngress + "," + GatewayApiDefault).
+		Build()
+	require.NoError(t, err)
+	kubeClient.UseNetworkingV1Ingress = true
+	return kubeClient, kubeClientSet, gwClient
+}
+
+func Test_CreateRoute_DualMode_CreatesHTTPRouteAndIngress(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, k8sClient, gwClient := newDualModeKubeClient(t)
+
+	route, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.NoError(err)
+	assertions.NotNil(route)
+
+	httpRouteList, err := gwClient.GatewayV1().HTTPRoutes(testNamespace1).List(ctx, metav1.ListOptions{})
+	assertions.NoError(err)
+	assertions.Len(httpRouteList.Items, 1)
+	assertions.Equal(testIngress, httpRouteList.Items[0].Name)
+
+	ingressList, err := k8sClient.NetworkingV1().Ingresses(testNamespace1).List(ctx, metav1.ListOptions{})
+	assertions.NoError(err)
+	assertions.Len(ingressList.Items, 1)
+	assertions.Equal("true", ingressList.Items[0].Annotations[IgnoreApiConverterAnnotation])
+}
+
+func Test_UpdateOrCreateRoute_DualMode_UpdatesBoth(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, k8sClient, gwClient := newDualModeKubeClient(t)
+
+	route := dualModeTestRoute()
+	_, err := kubeClient.CreateRoute(ctx, route, testNamespace1)
+	assertions.NoError(err)
+
+	route.Spec.Port.TargetPort = 9090
+	updated, err := kubeClient.UpdateOrCreateRoute(ctx, route, testNamespace1)
+	assertions.NoError(err)
+	assertions.NotNil(updated)
+
+	httpRoute, err := gwClient.GatewayV1().HTTPRoutes(testNamespace1).Get(ctx, testIngress, metav1.GetOptions{})
+	assertions.NoError(err)
+	assertions.NotEmpty(httpRoute.Spec.Rules[0].BackendRefs)
+
+	ingress, err := k8sClient.NetworkingV1().Ingresses(testNamespace1).Get(ctx, testIngress, metav1.GetOptions{})
+	assertions.NoError(err)
+	assertions.Equal(int32(9090), ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Port.Number)
+}
+
+func Test_DeleteRoute_DualMode_DeletesBoth(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, k8sClient, gwClient := newDualModeKubeClient(t)
+
+	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.NoError(err)
+
+	err = kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
+	assertions.NoError(err)
+
+	_, err = gwClient.GatewayV1().HTTPRoutes(testNamespace1).Get(ctx, testIngress, metav1.GetOptions{})
+	assertions.True(paasErrors.IsNotFound(err))
+
+	_, err = k8sClient.NetworkingV1().Ingresses(testNamespace1).Get(ctx, testIngress, metav1.GetOptions{})
+	assertions.True(paasErrors.IsNotFound(err))
+}
+
+func Test_CreateRoute_LegacyIngressOnly_NoIgnoreAnnotation(t *testing.T) {
 	assertions := require.New(t)
 	ctx := context.Background()
 
@@ -495,7 +592,7 @@ func Test_CreateRoute_WithBothModesIgnoresIngress(t *testing.T) {
 	certClientSet := &certClient.Clientset{}
 	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: certClientSet})
 	kubeClient.UseNetworkingV1Ingress = true
-	kubeClient.GatewaySystemType = "legacy-ingress" // Only Ingress, no Gateway API
+	kubeClient.GatewaySystem.Type = LegacyIngress
 
 	route, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
 	assertions.Nil(err)
@@ -504,7 +601,7 @@ func Test_CreateRoute_WithBothModesIgnoresIngress(t *testing.T) {
 	ingressList, err := kubeClientSet.NetworkingV1().Ingresses(testNamespace1).List(ctx, metav1.ListOptions{})
 	assertions.Nil(err)
 	assertions.Equal(1, len(ingressList.Items))
-	assertions.Empty(ingressList.Items[0].Annotations["gateway-api-converter.netcracker.com/ignore"])
+	assertions.Empty(ingressList.Items[0].Annotations[IgnoreApiConverterAnnotation])
 }
 
 func Test_ValidateAnnotationsForGatewayAPI_BackendProtocol(t *testing.T) {
@@ -529,12 +626,15 @@ func Test_ValidateAnnotationsForGatewayAPI_BackendProtocol(t *testing.T) {
 	kubeClientSet := fake.NewClientset()
 	certClientSet := &certClient.Clientset{}
 	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: certClientSet})
-	kubeClient.GatewaySystemType = GatewayApiDefault
+	kubeClient.GatewaySystem.Type = GatewayApiDefault
 
 	_, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
 	assertions.NotNil(err)
-	assertions.Contains(err.Error(), "backend-protocol")
-	assertions.Contains(err.Error(), "not supported for HTTPRoute creation")
+	assertions.True(paasErrors.IsInvalid(err))
+	var statusErr *paasErrors.StatusError
+	assertions.ErrorAs(err, &statusErr)
+	assertions.Equal(http.StatusUnprocessableEntity, int(statusErr.Status().Code))
+	assertions.Contains(statusErr.Status().Message, "backend-protocol")
 }
 
 func Test_ValidateAnnotationsForGatewayAPI_SSLPassthrough(t *testing.T) {
@@ -559,12 +659,15 @@ func Test_ValidateAnnotationsForGatewayAPI_SSLPassthrough(t *testing.T) {
 	kubeClientSet := fake.NewClientset()
 	certClientSet := &certClient.Clientset{}
 	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: certClientSet})
-	kubeClient.GatewaySystemType = GatewayApiDefault
+	kubeClient.GatewaySystem.Type = GatewayApiDefault
 
 	_, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
 	assertions.NotNil(err)
-	assertions.Contains(err.Error(), "ssl-passthrough")
-	assertions.Contains(err.Error(), "TLSRoute")
+	assertions.True(paasErrors.IsInvalid(err))
+	var statusErr *paasErrors.StatusError
+	assertions.ErrorAs(err, &statusErr)
+	assertions.Equal(http.StatusUnprocessableEntity, int(statusErr.Status().Code))
+	assertions.Contains(statusErr.Status().Message, "ssl-passthrough")
 }
 
 func Test_ValidateAnnotationsForGatewayAPI_AllowedAnnotations(t *testing.T) {
@@ -591,7 +694,7 @@ func Test_ValidateAnnotationsForGatewayAPI_AllowedAnnotations(t *testing.T) {
 	kubeClientSet := fake.NewClientset()
 	certClientSet := &certClient.Clientset{}
 	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: certClientSet})
-	kubeClient.GatewaySystemType = LegacyIngress // Only Ingress mode - no validation
+	kubeClient.GatewaySystem.Type = LegacyIngress
 
 	route, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
 	assertions.Nil(err)
@@ -621,7 +724,7 @@ func Test_ValidateAnnotationsForGatewayAPI_LegacyIngressAllowsCritical(t *testin
 	certClientSet := &certClient.Clientset{}
 	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: certClientSet})
 	kubeClient.UseNetworkingV1Ingress = true
-	kubeClient.GatewaySystemType = LegacyIngress // Only Ingress - should NOT validate
+	kubeClient.GatewaySystem.Type = LegacyIngress
 
 	route, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
 	assertions.Nil(err) // No error because legacy-ingress doesn't validate

--- a/service/internal/kubernetes/route_test.go
+++ b/service/internal/kubernetes/route_test.go
@@ -818,8 +818,8 @@ func Test_DeleteRoute_DualMode_BothNotFound_ReturnsNotFound(t *testing.T) {
 
 	err := kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
 	assertions.True(paasErrors.IsNotFound(err))
-	assertions.Contains(err.Error(), "httproute: not found")
-	assertions.Contains(err.Error(), "ingress: not found")
+	assertions.Regexp(`httproute: .* not found,`, err.Error())
+	assertions.Regexp(`, ingress: .* not found`, err.Error())
 }
 
 func Test_DeleteRoute_DualMode_DeletesBoth(t *testing.T) {

--- a/service/internal/kubernetes/route_test.go
+++ b/service/internal/kubernetes/route_test.go
@@ -510,6 +510,59 @@ func newDualModeKubeClient(t *testing.T) (*Kubernetes, *fake.Clientset, *gateway
 	return kubeClient, kubeClientSet, gwClient
 }
 
+func Test_CreateRoute_DualMode_HTTPRouteCreated_IngressFailed_ReturnsPartialCreateError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, k8sClient, gwClient := newDualModeKubeClient(t)
+
+	k8sClient.PrependReactor("create", "ingresses", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewInternalError(fmt.Errorf("ingress create failed"))
+	})
+
+	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.Error(err)
+	assertions.True(paasErrors.IsInternalError(err))
+	assertions.Contains(err.Error(), "HTTPRoute route was created, Ingress route was not created - try using Update endpoint")
+
+	httpRouteList, err := gwClient.GatewayV1().HTTPRoutes(testNamespace1).List(ctx, metav1.ListOptions{})
+	assertions.NoError(err)
+	assertions.Len(httpRouteList.Items, 1)
+
+	ingressList, err := k8sClient.NetworkingV1().Ingresses(testNamespace1).List(ctx, metav1.ListOptions{})
+	assertions.NoError(err)
+	assertions.Empty(ingressList.Items)
+}
+
+func Test_CreateRoute_DualMode_HTTPRouteFailed_IngressNotCreated(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	gwClient := gatewayclientfake.NewSimpleClientset()
+	gwClient.PrependReactor("create", "httproutes", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewInternalError(fmt.Errorf("httproute create failed"))
+	})
+	kubeClientSet := fake.NewClientset()
+	kubeClient, err := NewKubernetesClientBuilder().
+		WithNamespace(testNamespace1).
+		WithClient(&backend.KubernetesApi{
+			KubernetesInterface:  kubeClientSet,
+			CertmanagerInterface: &certClient.Clientset{},
+			GatewayInterface:     gwClient,
+		}).
+		WithGatewaySystemType(LegacyIngress + "," + GatewayApiDefault).
+		Build()
+	require.NoError(t, err)
+	kubeClient.UseNetworkingV1Ingress = true
+
+	_, err = kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.Error(err)
+	assertions.Contains(err.Error(), "failed to create HTTPRoute")
+	assertions.NotContains(err.Error(), "try using Update endpoint")
+
+	ingressList, err := kubeClientSet.NetworkingV1().Ingresses(testNamespace1).List(ctx, metav1.ListOptions{})
+	assertions.NoError(err)
+	assertions.Empty(ingressList.Items)
+}
+
 func Test_CreateRoute_DualMode_CreatesHTTPRouteAndIngress(t *testing.T) {
 	assertions := require.New(t)
 	ctx := context.Background()

--- a/service/internal/kubernetes/route_test.go
+++ b/service/internal/kubernetes/route_test.go
@@ -359,3 +359,272 @@ func Test_CreateRouteBG2_Enabled(t *testing.T) {
 	assertions.Nil(err)
 	assertions.NotNil(route)
 }
+
+func Test_ShouldUseGatewayAPI(t *testing.T) {
+	tests := []struct {
+		name              string
+		gatewaySystemType string
+		expected          bool
+	}{
+		{"Empty string", "", false},
+		{"Legacy ingress only", "legacy-ingress", false},
+		{"Gateway API default only", "gateway-api-default", true},
+		{"Both modes", "legacy-ingress,gateway-api-default", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kube := &Kubernetes{GatewaySystemType: tt.gatewaySystemType}
+			result := kube.shouldUseGatewayAPI()
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_ShouldCreateLegacyIngress(t *testing.T) {
+	tests := []struct {
+		name              string
+		gatewaySystemType string
+		expected          bool
+	}{
+		{"Empty string", "", true},
+		{"Legacy ingress only", "legacy-ingress", true},
+		{"Gateway API default only", "gateway-api-default", false},
+		{"Both modes", "legacy-ingress,gateway-api-default", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kube := &Kubernetes{GatewaySystemType: tt.gatewaySystemType}
+			result := kube.shouldCreateLegacyIngress()
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_ShouldIgnoreIngressForConverter(t *testing.T) {
+	tests := []struct {
+		name              string
+		gatewaySystemType string
+		expected          bool
+	}{
+		{"Empty string", "", false},
+		{"Legacy ingress only", "legacy-ingress", false},
+		{"Gateway API default only", "gateway-api-default", false},
+		{"Both modes", "legacy-ingress,gateway-api-default", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kube := &Kubernetes{GatewaySystemType: tt.gatewaySystemType}
+			result := kube.shouldIgnoreIngressForConverter()
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func Test_CreateRoute_GatewayAPIOnly_Error(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+
+	routeToCreate := &entity.Route{
+		Metadata: entity.Metadata{Name: testIngress, Namespace: testNamespace1},
+		Spec:     entity.RouteSpec{Host: "local"},
+	}
+
+	kubeClientSet := fake.NewClientset()
+	cert_client := &certClient.Clientset{}
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: cert_client})
+	kubeClient.GatewaySystemType = "invalid-type"
+
+	_, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
+	assertions.NotNil(err)
+	assertions.Contains(err.Error(), "does not allow any Route creation")
+}
+
+func Test_DeleteRoute_GatewayAPIOnly_Error(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+
+	kubeClientSet := fake.NewClientset()
+	cert_client := &certClient.Clientset{}
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: cert_client})
+	kubeClient.GatewaySystemType = "invalid-type"
+
+	err := kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
+	assertions.Nil(err) // DeleteRoute не возвращает ошибку, просто ничего не делает
+}
+
+func Test_UpdateOrCreateRoute_GatewayAPIOnly_Error(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+
+	routeToCreate := &entity.Route{
+		Metadata: entity.Metadata{Name: testIngress, Namespace: testNamespace1},
+		Spec:     entity.RouteSpec{Host: "local"},
+	}
+
+	kubeClientSet := fake.NewClientset()
+	cert_client := &certClient.Clientset{}
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: cert_client})
+	kubeClient.GatewaySystemType = "invalid-type"
+
+	_, err := kubeClient.UpdateOrCreateRoute(ctx, routeToCreate, testNamespace1)
+	assertions.NotNil(err)
+	assertions.Contains(err.Error(), "does not allow any Route update")
+}
+
+func Test_CreateRoute_WithBothModesIgnoresIngress(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+
+	routeToCreate := &entity.Route{
+		Metadata: entity.Metadata{
+			Name:      testIngress,
+			Namespace: testNamespace1,
+		},
+		Spec: entity.RouteSpec{
+			Host:    "test.example.com",
+			Path:    "/test",
+			Service: entity.Target{Name: "test-service"},
+			Port:    entity.RoutePort{TargetPort: 8080},
+		},
+	}
+
+	kubeClientSet := fake.NewClientset()
+	cert_client := &certClient.Clientset{}
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: cert_client})
+	kubeClient.UseNetworkingV1Ingress = true
+	kubeClient.GatewaySystemType = "legacy-ingress" // Only Ingress, no Gateway API
+
+	route, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
+	assertions.Nil(err)
+	assertions.NotNil(route)
+
+	// Verify Ingress created without ignore annotation (since only legacy-ingress mode)
+	ingressList, err := kubeClientSet.NetworkingV1().Ingresses(testNamespace1).List(ctx, metav1.ListOptions{})
+	assertions.Nil(err)
+	assertions.Equal(1, len(ingressList.Items))
+	assertions.Empty(ingressList.Items[0].Annotations["gateway-api-converter.netcracker.com/ignore"])
+}
+
+func Test_ValidateAnnotationsForGatewayAPI_BackendProtocol(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+
+	routeToCreate := &entity.Route{
+		Metadata: entity.Metadata{
+			Name:      testIngress,
+			Namespace: testNamespace1,
+			Annotations: map[string]string{
+				AnnotationBackendProtocol: "HTTPS",
+			},
+		},
+		Spec: entity.RouteSpec{
+			Host:    "test.example.com",
+			Service: entity.Target{Name: "test-service"},
+			Port:    entity.RoutePort{TargetPort: 8080},
+		},
+	}
+
+	kubeClientSet := fake.NewClientset()
+	cert_client := &certClient.Clientset{}
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: cert_client})
+	kubeClient.GatewaySystemType = GatewayApiDefault
+
+	_, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
+	assertions.NotNil(err)
+	assertions.Contains(err.Error(), "backend-protocol")
+	assertions.Contains(err.Error(), "not supported for HTTPRoute creation")
+}
+
+func Test_ValidateAnnotationsForGatewayAPI_SSLPassthrough(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+
+	routeToCreate := &entity.Route{
+		Metadata: entity.Metadata{
+			Name:      testIngress,
+			Namespace: testNamespace1,
+			Annotations: map[string]string{
+				AnnotationSSLPassthrough: "true",
+			},
+		},
+		Spec: entity.RouteSpec{
+			Host:    "test.example.com",
+			Service: entity.Target{Name: "test-service"},
+			Port:    entity.RoutePort{TargetPort: 8080},
+		},
+	}
+
+	kubeClientSet := fake.NewClientset()
+	cert_client := &certClient.Clientset{}
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: cert_client})
+	kubeClient.GatewaySystemType = GatewayApiDefault
+
+	_, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
+	assertions.NotNil(err)
+	assertions.Contains(err.Error(), "ssl-passthrough")
+	assertions.Contains(err.Error(), "TLSRoute")
+}
+
+func Test_ValidateAnnotationsForGatewayAPI_AllowedAnnotations(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+
+	routeToCreate := &entity.Route{
+		Metadata: entity.Metadata{
+			Name:      testIngress,
+			Namespace: testNamespace1,
+			Annotations: map[string]string{
+				entity.AnnotationAffinity:          "cookie",
+				entity.AnnotationSessionCookieName: "my-cookie",
+				entity.AnnotationProxyReadTimeout:  "1800",
+			},
+		},
+		Spec: entity.RouteSpec{
+			Host:    "test.example.com",
+			Service: entity.Target{Name: "test-service"},
+			Port:    entity.RoutePort{TargetPort: 8080},
+		},
+	}
+
+	kubeClientSet := fake.NewClientset()
+	cert_client := &certClient.Clientset{}
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: cert_client})
+	kubeClient.GatewaySystemType = LegacyIngress // Only Ingress mode - no validation
+
+	route, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
+	assertions.Nil(err)
+	assertions.NotNil(route)
+}
+
+func Test_ValidateAnnotationsForGatewayAPI_LegacyIngressAllowsCritical(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+
+	routeToCreate := &entity.Route{
+		Metadata: entity.Metadata{
+			Name:      testIngress,
+			Namespace: testNamespace1,
+			Annotations: map[string]string{
+				AnnotationBackendProtocol: "HTTPS",
+			},
+		},
+		Spec: entity.RouteSpec{
+			Host:    "test.example.com",
+			Service: entity.Target{Name: "test-service"},
+			Port:    entity.RoutePort{TargetPort: 8080},
+		},
+	}
+
+	kubeClientSet := fake.NewClientset()
+	cert_client := &certClient.Clientset{}
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: cert_client})
+	kubeClient.UseNetworkingV1Ingress = true
+	kubeClient.GatewaySystemType = LegacyIngress // Only Ingress - should NOT validate
+
+	route, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
+	assertions.Nil(err) // No error because legacy-ingress doesn't validate
+	assertions.NotNil(route)
+}

--- a/service/internal/kubernetes/route_test.go
+++ b/service/internal/kubernetes/route_test.go
@@ -362,69 +362,6 @@ func Test_CreateRouteBG2_Enabled(t *testing.T) {
 	assertions.NotNil(route)
 }
 
-func Test_ShouldUseGatewayAPI(t *testing.T) {
-	tests := []struct {
-		name              string
-		gatewaySystemType string
-		expected          bool
-	}{
-		{"Empty string", "", false},
-		{"Legacy ingress only", "legacy-ingress", false},
-		{"Gateway API default only", "gateway-api-default", true},
-		{"Both modes", "legacy-ingress,gateway-api-default", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gs := GatewaySystem{Type: tt.gatewaySystemType}
-			result := gs.ShouldUseGatewayAPI()
-			require.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func Test_ShouldCreateLegacyIngress(t *testing.T) {
-	tests := []struct {
-		name              string
-		gatewaySystemType string
-		expected          bool
-	}{
-		{"Empty string", "", true},
-		{"Legacy ingress only", "legacy-ingress", true},
-		{"Gateway API default only", "gateway-api-default", false},
-		{"Both modes", "legacy-ingress,gateway-api-default", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gs := GatewaySystem{Type: tt.gatewaySystemType}
-			result := gs.ShouldCreateLegacyIngress()
-			require.Equal(t, tt.expected, result)
-		})
-	}
-}
-
-func Test_ShouldIgnoreIngressForConverter(t *testing.T) {
-	tests := []struct {
-		name              string
-		gatewaySystemType string
-		expected          bool
-	}{
-		{"Empty string", "", false},
-		{"Legacy ingress only", "legacy-ingress", false},
-		{"Gateway API default only", "gateway-api-default", false},
-		{"Both modes", "legacy-ingress,gateway-api-default", true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gs := GatewaySystem{Type: tt.gatewaySystemType}
-			result := gs.ShouldIgnoreIngressForConverter()
-			require.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func Test_CreateRoute_GatewayAPIOnly_Error(t *testing.T) {
 	assertions := require.New(t)
 	ctx := context.Background()
@@ -474,6 +411,70 @@ func Test_UpdateOrCreateRoute_GatewayAPIOnly_Error(t *testing.T) {
 	_, err := kubeClient.UpdateOrCreateRoute(ctx, routeToCreate, testNamespace1)
 	assertions.NotNil(err)
 	assertions.Contains(err.Error(), "does not allow any Route update")
+}
+
+func newGatewayAPIOnlyKubeClient(t *testing.T) (*Kubernetes, *gatewayclientfake.Clientset) {
+	t.Helper()
+	gwClient := gatewayclientfake.NewSimpleClientset()
+	kubeClient, err := NewKubernetesClientBuilder().
+		WithNamespace(testNamespace1).
+		WithClient(&backend.KubernetesApi{
+			KubernetesInterface:  fake.NewClientset(),
+			CertmanagerInterface: &certClient.Clientset{},
+			GatewayInterface:     gwClient,
+		}).
+		WithGatewaySystemType(GatewayApiDefault).
+		Build()
+	require.NoError(t, err)
+	return kubeClient, gwClient
+}
+
+func Test_CreateRoute_GatewayAPIOnly_Success(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, gwClient := newGatewayAPIOnlyKubeClient(t)
+
+	route, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.NoError(err)
+	assertions.NotNil(route)
+
+	list, err := gwClient.GatewayV1().HTTPRoutes(testNamespace1).List(ctx, metav1.ListOptions{})
+	assertions.NoError(err)
+	assertions.Len(list.Items, 1)
+}
+
+func Test_UpdateOrCreateRoute_GatewayAPIOnly_UpdatesHTTPRoute(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, gwClient := newGatewayAPIOnlyKubeClient(t)
+
+	route := dualModeTestRoute()
+	_, err := kubeClient.CreateRoute(ctx, route, testNamespace1)
+	assertions.NoError(err)
+
+	route.Spec.Port.TargetPort = 7070
+	updated, err := kubeClient.UpdateOrCreateRoute(ctx, route, testNamespace1)
+	assertions.NoError(err)
+	assertions.NotNil(updated)
+
+	httpRoute, err := gwClient.GatewayV1().HTTPRoutes(testNamespace1).Get(ctx, testIngress, metav1.GetOptions{})
+	assertions.NoError(err)
+	assertions.NotEmpty(httpRoute.Spec.Rules[0].BackendRefs)
+}
+
+func Test_DeleteRoute_GatewayAPIOnly_DeletesHTTPRoute(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, gwClient := newGatewayAPIOnlyKubeClient(t)
+
+	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.NoError(err)
+
+	err = kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
+	assertions.NoError(err)
+
+	_, err = gwClient.GatewayV1().HTTPRoutes(testNamespace1).Get(ctx, testIngress, metav1.GetOptions{})
+	assertions.True(paasErrors.IsNotFound(err))
 }
 
 func dualModeTestRoute() *entity.Route {
@@ -729,4 +730,247 @@ func Test_ValidateAnnotationsForGatewayAPI_LegacyIngressAllowsCritical(t *testin
 	route, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
 	assertions.Nil(err) // No error because legacy-ingress doesn't validate
 	assertions.NotNil(route)
+}
+
+func newTinyRouteCache(t *testing.T, caches ...cache.CacheName) *cache.ResourcesCache {
+	t.Helper()
+	resourcesCache, err := cache.NewResourcesCache(2, 100, 1, 0, caches...)
+	require.NoError(t, err)
+	return resourcesCache
+}
+
+func Test_CreateRoute_GatewayAPIOnly_ReturnsHTTPRouteWithoutIngress(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClientSet := fake.NewClientset()
+	gwClient := gatewayclientfake.NewSimpleClientset()
+	kubeClient, err := NewKubernetesClientBuilder().
+		WithNamespace(testNamespace1).
+		WithClient(&backend.KubernetesApi{
+			KubernetesInterface:  kubeClientSet,
+			CertmanagerInterface: &certClient.Clientset{},
+			GatewayInterface:     gwClient,
+		}).
+		WithGatewaySystemType(GatewayApiDefault).
+		Build()
+	require.NoError(t, err)
+
+	route, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.NoError(err)
+	assertions.NotNil(route)
+	assertions.Equal(testIngress, route.Name)
+
+	ingressList, err := kubeClientSet.NetworkingV1().Ingresses(testNamespace1).List(ctx, metav1.ListOptions{})
+	assertions.NoError(err)
+	assertions.Empty(ingressList.Items)
+}
+
+func Test_CreateRoute_GatewayAPIOnly_PlacesHTTPRouteInCache(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, _ := newGatewayAPIOnlyKubeClient(t)
+	kubeClient.Cache = cache.NewTestResourcesCache(cache.HttpRouteCache)
+
+	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.NoError(err)
+
+	cached := kubeClient.Cache.HTTPRoute.Get(ctx, testNamespace1, testIngress)
+	assertions.NotNil(cached)
+	assertions.Equal(testIngress, cached.Name)
+}
+
+func Test_CreateRoute_GatewayAPIOnly_HTTPRouteCacheSetError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, gwClient := newGatewayAPIOnlyKubeClient(t)
+	kubeClient.Cache = newTinyRouteCache(t, cache.HttpRouteCache)
+
+	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.Error(err)
+	assertions.Contains(err.Error(), "failed to place HTTPRoute into cache")
+
+	list, err := gwClient.GatewayV1().HTTPRoutes(testNamespace1).List(ctx, metav1.ListOptions{})
+	assertions.NoError(err)
+	assertions.Len(list.Items, 1)
+}
+
+func Test_CreateRoute_GatewayAPIOnly_HTTPRouteCreateError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	gwClient := gatewayclientfake.NewSimpleClientset()
+	gwClient.PrependReactor("create", "httproutes", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("httproute create failed")
+	})
+	kubeClient, err := NewKubernetesClientBuilder().
+		WithNamespace(testNamespace1).
+		WithClient(&backend.KubernetesApi{
+			KubernetesInterface:  fake.NewClientset(),
+			CertmanagerInterface: &certClient.Clientset{},
+			GatewayInterface:     gwClient,
+		}).
+		WithGatewaySystemType(GatewayApiDefault).
+		Build()
+	require.NoError(t, err)
+
+	_, err = kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.Error(err)
+	assertions.Contains(err.Error(), "failed to create HTTPRoute")
+}
+
+func Test_CreateRoute_NetworkingV1_IngressCreateError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClientSet := fake.NewClientset()
+	kubeClientSet.PrependReactor("create", "ingresses", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewInternalError(fmt.Errorf("ingress create failed"))
+	})
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{
+		KubernetesInterface:  kubeClientSet,
+		CertmanagerInterface: &certClient.Clientset{},
+	})
+	kubeClient.UseNetworkingV1Ingress = true
+	kubeClient.GatewaySystem.Type = LegacyIngress
+
+	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.Error(err)
+	assertions.Contains(err.Error(), "ingress create failed")
+}
+
+func Test_CreateRoute_V1beta1_IngressCreateError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClientSet := fake.NewClientset()
+	kubeClientSet.PrependReactor("create", "ingresses", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewInternalError(fmt.Errorf("extensions ingress create failed"))
+	})
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{
+		KubernetesInterface:  kubeClientSet,
+		CertmanagerInterface: &certClient.Clientset{},
+	})
+	kubeClient.GatewaySystem.Type = LegacyIngress
+
+	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.Error(err)
+	assertions.Contains(err.Error(), "extensions ingress create failed")
+}
+
+func Test_CreateRoute_NetworkingV1_IngressCacheSetError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClientSet := fake.NewClientset()
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{
+		KubernetesInterface:  kubeClientSet,
+		CertmanagerInterface: &certClient.Clientset{},
+	})
+	kubeClient.UseNetworkingV1Ingress = true
+	kubeClient.GatewaySystem.Type = LegacyIngress
+	kubeClient.Cache = newTinyRouteCache(t, cache.RouteCache)
+
+	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.Error(err)
+	assertions.Contains(err.Error(), "faield to place ingress into cache")
+
+	ingressList, err := kubeClientSet.NetworkingV1().Ingresses(testNamespace1).List(ctx, metav1.ListOptions{})
+	assertions.NoError(err)
+	assertions.Len(ingressList.Items, 1)
+}
+
+func Test_CreateRoute_V1beta1_IngressCacheSetError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClientSet := fake.NewClientset()
+	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{
+		KubernetesInterface:  kubeClientSet,
+		CertmanagerInterface: &certClient.Clientset{},
+	})
+	kubeClient.GatewaySystem.Type = LegacyIngress
+	kubeClient.Cache = newTinyRouteCache(t, cache.RouteCache)
+
+	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.Error(err)
+	assertions.Contains(err.Error(), "faield to place ingress into cache")
+
+	ingressList, err := kubeClientSet.ExtensionsV1beta1().Ingresses(testNamespace1).List(ctx, metav1.ListOptions{})
+	assertions.NoError(err)
+	assertions.Len(ingressList.Items, 1)
+}
+
+func newDualModeV1beta1KubeClient(t *testing.T) (*Kubernetes, *fake.Clientset, *gatewayclientfake.Clientset) {
+	t.Helper()
+	kubeClient, k8sClient, gwClient := newDualModeKubeClient(t)
+	kubeClient.UseNetworkingV1Ingress = false
+	return kubeClient, k8sClient, gwClient
+}
+
+func Test_CreateRoute_DualMode_V1beta1_SetsIgnoreAnnotationOnNilAnnotations(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, k8sClient, gwClient := newDualModeV1beta1KubeClient(t)
+
+	route, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.NoError(err)
+	assertions.NotNil(route)
+
+	httpRouteList, err := gwClient.GatewayV1().HTTPRoutes(testNamespace1).List(ctx, metav1.ListOptions{})
+	assertions.NoError(err)
+	assertions.Len(httpRouteList.Items, 1)
+
+	ingressList, err := k8sClient.ExtensionsV1beta1().Ingresses(testNamespace1).List(ctx, metav1.ListOptions{})
+	assertions.NoError(err)
+	assertions.Len(ingressList.Items, 1)
+	assertions.Equal("true", ingressList.Items[0].Annotations[IgnoreApiConverterAnnotation])
+}
+
+func Test_ValidateAnnotationsForGatewayAPI_CriticalAnnotations(t *testing.T) {
+	tests := []struct {
+		name       string
+		annotation string
+		value      string
+		message    string
+	}{
+		{"backend protocol", AnnotationBackendProtocol, "HTTPS", BackendTlsOrTrafficWarning},
+		{"secure backends", AnnotationSecureBackends, "true", BackendTLSWarning},
+		{"auth type", AnnotationAuthType, "basic", SecurityPolicyWarning},
+		{"ssl passthrough", AnnotationSSLPassthrough, "true", TlsRouteWarning},
+		{"config snippet", AnnotationConfigSnippet, "more_set_headers", ConfigSnippetWarning},
+		{"upstream vhost", AnnotationUpstreamVhost, "example.com", EnvoyExtensionWarning},
+		{"proxy redirect from", AnnotationProxyRedirectFrom, "/a", EnvoyExtensionWarning},
+		{"proxy redirect to", AnnotationProxyRedirectTo, "/b", EnvoyExtensionWarning},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertions := require.New(t)
+			ctx := context.Background()
+
+			routeToCreate := &entity.Route{
+				Metadata: entity.Metadata{
+					Name:      testIngress,
+					Namespace: testNamespace1,
+					Annotations: map[string]string{
+						tt.annotation: tt.value,
+					},
+				},
+				Spec: entity.RouteSpec{
+					Host:    "test.example.com",
+					Service: entity.Target{Name: "test-service"},
+					Port:    entity.RoutePort{TargetPort: 8080},
+				},
+			}
+
+			kubeClientSet := fake.NewClientset()
+			certClientSet := &certClient.Clientset{}
+			kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{
+				KubernetesInterface:  kubeClientSet,
+				CertmanagerInterface: certClientSet,
+			})
+			kubeClient.GatewaySystem.Type = GatewayApiDefault
+
+			_, err := kubeClient.CreateRoute(ctx, routeToCreate, testNamespace1)
+			assertions.Error(err)
+			assertions.True(paasErrors.IsInvalid(err))
+			var statusErr *paasErrors.StatusError
+			assertions.ErrorAs(err, &statusErr)
+			assertions.Contains(statusErr.Status().Message, tt.message)
+		})
+	}
 }

--- a/service/internal/kubernetes/route_test.go
+++ b/service/internal/kubernetes/route_test.go
@@ -553,6 +553,24 @@ func Test_UpdateOrCreateRoute_DualMode_UpdatesBoth(t *testing.T) {
 	assertions.Equal(int32(9090), ingress.Spec.Rules[0].HTTP.Paths[0].Backend.Service.Port.Number)
 }
 
+func Test_DeleteRoute_DualMode_HTTPRouteDeleted_IngressNotFound_NoError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, k8sClient, gwClient := newDualModeKubeClient(t)
+
+	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.NoError(err)
+
+	err = k8sClient.NetworkingV1().Ingresses(testNamespace1).Delete(ctx, testIngress, metav1.DeleteOptions{})
+	assertions.NoError(err)
+
+	err = kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
+	assertions.NoError(err)
+
+	_, err = gwClient.GatewayV1().HTTPRoutes(testNamespace1).Get(ctx, testIngress, metav1.GetOptions{})
+	assertions.True(paasErrors.IsNotFound(err))
+}
+
 func Test_DeleteRoute_DualMode_DeletesBoth(t *testing.T) {
 	assertions := require.New(t)
 	ctx := context.Background()
@@ -968,13 +986,13 @@ func Test_UpdateOrCreateRoute_GatewayAPIOnly_PlacesHTTPRouteInCache(t *testing.T
 	assertions.NotNil(cached)
 }
 
-func Test_DeleteRoute_GatewayAPIOnly_HTTPRouteNotFound_NoError(t *testing.T) {
+func Test_DeleteRoute_GatewayAPIOnly_HTTPRouteNotFound_ReturnsNotFound(t *testing.T) {
 	assertions := require.New(t)
 	ctx := context.Background()
 	kubeClient, _ := newGatewayAPIOnlyKubeClient(t)
 
 	err := kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
-	assertions.NoError(err)
+	assertions.True(paasErrors.IsNotFound(err))
 }
 
 func Test_DeleteRoute_GatewayAPIOnly_HTTPRouteDeleteError(t *testing.T) {
@@ -1004,7 +1022,7 @@ func Test_DeleteRoute_GatewayAPIOnly_HTTPRouteDeleteError(t *testing.T) {
 	assertions.Contains(err.Error(), "httproute delete failed")
 }
 
-func Test_DeleteRoute_LegacyIngress_NetworkingV1_IngressNotFound_NoError(t *testing.T) {
+func Test_DeleteRoute_LegacyIngress_NetworkingV1_IngressNotFound_ReturnsNotFound(t *testing.T) {
 	assertions := require.New(t)
 	ctx := context.Background()
 	kubeClientSet := fake.NewClientset()
@@ -1016,7 +1034,7 @@ func Test_DeleteRoute_LegacyIngress_NetworkingV1_IngressNotFound_NoError(t *test
 	kubeClient.GatewaySystem.Type = LegacyIngress
 
 	err := kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
-	assertions.NoError(err)
+	assertions.True(paasErrors.IsNotFound(err))
 }
 
 func Test_DeleteRoute_LegacyIngress_NetworkingV1_IngressDeleteError(t *testing.T) {
@@ -1042,7 +1060,7 @@ func Test_DeleteRoute_LegacyIngress_NetworkingV1_IngressDeleteError(t *testing.T
 	assertions.Contains(err.Error(), "ingress delete failed")
 }
 
-func Test_DeleteRoute_LegacyIngress_V1beta1_IngressNotFound_NoError(t *testing.T) {
+func Test_DeleteRoute_LegacyIngress_V1beta1_IngressNotFound_ReturnsNotFound(t *testing.T) {
 	assertions := require.New(t)
 	ctx := context.Background()
 	kubeClientSet := fake.NewClientset()
@@ -1053,7 +1071,7 @@ func Test_DeleteRoute_LegacyIngress_V1beta1_IngressNotFound_NoError(t *testing.T
 	kubeClient.GatewaySystem.Type = LegacyIngress
 
 	err := kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
-	assertions.NoError(err)
+	assertions.True(paasErrors.IsNotFound(err))
 }
 
 func Test_DeleteRoute_LegacyIngress_V1beta1_IngressDeleteError(t *testing.T) {

--- a/service/platformservice.go
+++ b/service/platformservice.go
@@ -192,17 +192,21 @@ func createPlatformService(builder PlatformClientBuilder) (PlatformService, erro
 	if builder.gatewaySystemNamespace != nil {
 		gatewaySystemNamespace = *builder.gatewaySystemNamespace
 	} else {
-		gatewaySystemNamespace = configloader.GetOrDefaultString("gateway.system.namespace", "gateway-system")
+		gatewaySystemNamespace = configloader.GetOrDefaultString("gateway.system.namespace", "")
 	}
-	kubeClientBuilder = kubeClientBuilder.WithGatewaySystemNamespace(gatewaySystemNamespace)
+	if gatewaySystemNamespace != "" {
+		kubeClientBuilder = kubeClientBuilder.WithGatewaySystemNamespace(gatewaySystemNamespace)
+	}
 
 	var gatewaySystemName string
 	if builder.gatewaySystemName != nil {
 		gatewaySystemName = *builder.gatewaySystemName
 	} else {
-		gatewaySystemName = configloader.GetOrDefaultString("gateway.system.name", "default-external-gateway")
+		gatewaySystemName = configloader.GetOrDefaultString("gateway.system.name", "")
 	}
-	kubeClientBuilder = kubeClientBuilder.WithGatewaySystemName(gatewaySystemName)
+	if gatewaySystemName != "" {
+		kubeClientBuilder = kubeClientBuilder.WithGatewaySystemName(gatewaySystemName)
+	}
 
 	kubeClient, err := kubeClientBuilder.Build()
 

--- a/service/platformservice.go
+++ b/service/platformservice.go
@@ -182,7 +182,7 @@ func createPlatformService(builder PlatformClientBuilder) (PlatformService, erro
 	if builder.gatewaySystemType != nil {
 		gatewaySystemType = *builder.gatewaySystemType
 	} else {
-		gatewaySystemType = configloader.GetOrDefaultString("gateway.system.type", "")
+		gatewaySystemType = configloader.GetOrDefaultString(kubernetes.GatewaySystemTypeProperty, "")
 	}
 	if gatewaySystemType != "" {
 		kubeClientBuilder = kubeClientBuilder.WithGatewaySystemType(gatewaySystemType)
@@ -192,7 +192,7 @@ func createPlatformService(builder PlatformClientBuilder) (PlatformService, erro
 	if builder.gatewaySystemNamespace != nil {
 		gatewaySystemNamespace = *builder.gatewaySystemNamespace
 	} else {
-		gatewaySystemNamespace = configloader.GetOrDefaultString("gateway.system.namespace", "")
+		gatewaySystemNamespace = configloader.GetOrDefaultString(kubernetes.GatewaySystemNamespaceProperty, "")
 	}
 	if gatewaySystemNamespace != "" {
 		kubeClientBuilder = kubeClientBuilder.WithGatewaySystemNamespace(gatewaySystemNamespace)
@@ -202,7 +202,7 @@ func createPlatformService(builder PlatformClientBuilder) (PlatformService, erro
 	if builder.gatewaySystemName != nil {
 		gatewaySystemName = *builder.gatewaySystemName
 	} else {
-		gatewaySystemName = configloader.GetOrDefaultString("gateway.system.name", "")
+		gatewaySystemName = configloader.GetOrDefaultString(kubernetes.GatewaySystemNameProperty, "")
 	}
 	if gatewaySystemName != "" {
 		kubeClientBuilder = kubeClientBuilder.WithGatewaySystemName(gatewaySystemName)

--- a/service/platformservice.go
+++ b/service/platformservice.go
@@ -168,7 +168,7 @@ func createPlatformService(builder PlatformClientBuilder) (PlatformService, erro
 	if err != nil {
 		return nil, err
 	}
-	kubeClient, err := kubernetes.NewKubernetesClientBuilder().
+	kubeClientBuilder := kubernetes.NewKubernetesClientBuilder().
 		WithNamespace(namespace).
 		WithClient(kubernetesClient).
 		WithRolloutExecutor(rolloutExecutor).
@@ -176,8 +176,35 @@ func createPlatformService(builder PlatformClientBuilder) (PlatformService, erro
 		WithWatchClientTimeout(watchClientTimeout).
 		WithBadResources(builder.badResources).
 		WithCache(resourcesCache).
-		WithBG2Enabled(bg2EnabledFunc).
-		Build()
+		WithBG2Enabled(bg2EnabledFunc)
+
+	var gatewaySystemType string
+	if builder.gatewaySystemType != nil {
+		gatewaySystemType = *builder.gatewaySystemType
+	} else {
+		gatewaySystemType = configloader.GetOrDefaultString("gateway.system.type", "")
+	}
+	if gatewaySystemType != "" {
+		kubeClientBuilder = kubeClientBuilder.WithGatewaySystemType(gatewaySystemType)
+	}
+
+	var gatewaySystemNamespace string
+	if builder.gatewaySystemNamespace != nil {
+		gatewaySystemNamespace = *builder.gatewaySystemNamespace
+	} else {
+		gatewaySystemNamespace = configloader.GetOrDefaultString("gateway.system.namespace", "gateway-system")
+	}
+	kubeClientBuilder = kubeClientBuilder.WithGatewaySystemNamespace(gatewaySystemNamespace)
+
+	var gatewaySystemName string
+	if builder.gatewaySystemName != nil {
+		gatewaySystemName = *builder.gatewaySystemName
+	} else {
+		gatewaySystemName = configloader.GetOrDefaultString("gateway.system.name", "default-external-gateway")
+	}
+	kubeClientBuilder = kubeClientBuilder.WithGatewaySystemName(gatewaySystemName)
+
+	kubeClient, err := kubeClientBuilder.Build()
 
 	if err != nil {
 		return nil, err

--- a/service/platformservice_test.go
+++ b/service/platformservice_test.go
@@ -111,3 +111,44 @@ func TestCreatePlatformService_Consul_Enabled(t *testing.T) {
 func createTestServer(fn func(w http.ResponseWriter, r *http.Request)) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(fn))
 }
+
+func TestCreatePlatformService_WithGatewaySystemFromBuilder_k8s(t *testing.T) {
+	r := require.New(t)
+	prepareEnv("kubernetes")
+	defer cleanUpEnv()
+
+	builder := NewPlatformClientBuilder().
+		WithPlatformType(types.Kubernetes).
+		WithClients(prepareFakeClients()).
+		WithNamespace(testNamespace).
+		WithWatchExecutor(getTestWatchExecutor(t)).
+		WithGatewaySystemType("gateway-api-default").
+		WithGatewaySystemNamespace("builder-ns").
+		WithGatewaySystemName("builder-gateway")
+
+	client, err := createPlatformService(builder)
+	r.NoError(err)
+	kube := getK8sEntityFromClient(client)
+	r.Equal("gateway-api-default", kube.GatewaySystem.Type)
+	r.Equal("builder-ns", kube.GatewaySystem.Namespace)
+	r.Equal("builder-gateway", kube.GatewaySystem.Name)
+}
+
+func TestCreatePlatformService_GatewaySystemDefaultsWithoutConfig_k8s(t *testing.T) {
+	r := require.New(t)
+	prepareEnv("kubernetes")
+	defer cleanUpEnv()
+
+	builder := NewPlatformClientBuilder().
+		WithPlatformType(types.Kubernetes).
+		WithClients(prepareFakeClients()).
+		WithNamespace(testNamespace).
+		WithWatchExecutor(getTestWatchExecutor(t))
+
+	client, err := createPlatformService(builder)
+	r.NoError(err)
+	kube := getK8sEntityFromClient(client)
+	r.Empty(kube.GatewaySystem.Type)
+	r.Equal("gateway-system", kube.GatewaySystem.Namespace)
+	r.Equal("default-external-gateway", kube.GatewaySystem.Name)
+}


### PR DESCRIPTION
# What does this MR do?

Implements Gateway API migration support alongside legacy Ingress resources. The system now supports creating HTTPRoute (Gateway API v1) resources  in addition to or instead of traditional Ingress resources, controlled by the GATEWAY_SYSTEM_TYPE property. 
This flag may contain these values:

- legacy-ingress - when you need to deploy only Ingress.yaml. It is a default value
- gateway-api-default - when you need to deploy only Httproute.yaml
- legacy-ingress,gateway-api-default - when you need both Httproute.yaml and Ingress.yaml files.

New entity methods:
    - Route.ToHTTPRoute() - converts Route to Gateway API HTTPRoute
    - RouteFromHTTPRouteGatewayV1() - reverse conversion



