### PR TITLE
fix: fix wrong error formatting

### DIFF
--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -112,16 +112,13 @@ func dualModeRouteError(httpRouteRes, ingressRes routeResourceResult) error {
 		return nil
 	}
 
-	if httpRouteRes.err == nil || ingressRes.err == nil {
-		return fmt.Errorf(
-			"%s%s: %w",
-			formatDualModeRouteStatus(httpRouteRes, ingressRes),
-			dualModeRouteUpdateHint,
-			cmp.Or(httpRouteRes.err, ingressRes.err),
-		)
+	if httpRouteRes.err != nil && ingressRes.err != nil {
+		return fmt.Errorf("httproute: error: %w, ingress: error: %w", httpRouteRes.err, ingressRes.err)
 	}
 
-	return fmt.Errorf("httproute: error: %w, ingress: error: %w", httpRouteRes.err, ingressRes.err)
+	failedErr := cmp.Or(httpRouteRes.err, ingressRes.err)
+	status := formatDualModeRouteStatus(httpRouteRes, ingressRes)
+	return fmt.Errorf("%s%s: %w", status, dualModeRouteUpdateHint, failedErr)
 }
 
 func finishRouteOperation(route *entity.Route, status string) (*entity.Route, error) {

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -43,6 +43,7 @@ const (
 
 const (
 	dualModeRouteUpdateHint = " - try using Update endpoint"
+	dualModeStatusFormat    = "%s, %s"
 	routeStatusCreated      = "created"
 	routeStatusUpdated      = "updated"
 )
@@ -134,14 +135,14 @@ func pickDualModeRouteResult(ingressRes, httpRouteRes routeResourceResult) *enti
 }
 
 func formatDualModeRouteStatus(httpRouteRes, ingressRes routeResourceResult) string {
-	return fmt.Sprintf("%s, %s",
+	return fmt.Sprintf(dualModeStatusFormat,
 		formatRouteResourceStatus("httproute", httpRouteRes),
 		formatRouteResourceStatus("ingress", ingressRes),
 	)
 }
 
 func formatDualModeRouteStatusSummary(httpRouteRes, ingressRes routeResourceResult) string {
-	return fmt.Sprintf("%s, %s",
+	return fmt.Sprintf(dualModeStatusFormat,
 		formatRouteResourceStatusSummary("httproute", httpRouteRes),
 		formatRouteResourceStatusSummary("ingress", ingressRes),
 	)
@@ -166,7 +167,7 @@ func isDeleteFailure(err error) bool {
 }
 
 func formatDualModeDeleteRouteStatus(httpRouteErr, ingressErr error) string {
-	return fmt.Sprintf("%s, %s",
+	return fmt.Sprintf(dualModeStatusFormat,
 		routeResourceDeleteStatus("httproute", httpRouteErr),
 		routeResourceDeleteStatus("ingress", ingressErr),
 	)

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 
@@ -107,13 +108,17 @@ func resolveRouteResult(
 }
 
 func dualModeRouteError(httpRouteRes, ingressRes routeResourceResult) error {
+	if httpRouteRes.err == nil && ingressRes.err == nil {
+		return nil
+	}
+
 	if httpRouteRes.err == nil || ingressRes.err == nil {
-		failedErr := httpRouteRes.err
-		if failedErr == nil {
-			failedErr = ingressRes.err
-		}
-		status := formatDualModeRouteStatus(httpRouteRes, ingressRes)
-		return fmt.Errorf("%s%s: %w", status, dualModeRouteUpdateHint, failedErr)
+		return fmt.Errorf(
+			"%s%s: %w",
+			formatDualModeRouteStatus(httpRouteRes, ingressRes),
+			dualModeRouteUpdateHint,
+			cmp.Or(httpRouteRes.err, ingressRes.err),
+		)
 	}
 
 	return fmt.Errorf("httproute: error: %w, ingress: error: %w", httpRouteRes.err, ingressRes.err)

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -90,12 +90,7 @@ func resolveRouteResult(
 			return finishRouteOperation(pickDualModeRouteResult(ingressRes, httpRouteRes), formatDualModeRouteStatus(httpRouteRes, ingressRes))
 		}
 
-		status := formatDualModeRouteStatus(httpRouteRes, ingressRes)
-		if httpRouteRes.err == nil || ingressRes.err == nil {
-			return nil, paasErrors.NewInternalError(fmt.Errorf("%s%s", status, dualModeRouteUpdateHint))
-		}
-
-		return nil, paasErrors.NewInternalError(fmt.Errorf("%s", status))
+		return nil, dualModeRouteError(httpRouteRes, ingressRes)
 	}
 
 	if useGatewayAPI {
@@ -106,9 +101,22 @@ func resolveRouteResult(
 	}
 
 	if ingressRes.err != nil {
-		return nil, ingressRes.err
+		return nil, fmt.Errorf("ingress: error: %w", ingressRes.err)
 	}
 	return finishRouteOperation(ingressRes.route, formatRouteResourceStatus("ingress", ingressRes))
+}
+
+func dualModeRouteError(httpRouteRes, ingressRes routeResourceResult) error {
+	if httpRouteRes.err == nil || ingressRes.err == nil {
+		failedErr := httpRouteRes.err
+		if failedErr == nil {
+			failedErr = ingressRes.err
+		}
+		status := formatDualModeRouteStatus(httpRouteRes, ingressRes)
+		return fmt.Errorf("%s%s: %w", status, dualModeRouteUpdateHint, failedErr)
+	}
+
+	return fmt.Errorf("httproute: error: %w, ingress: error: %w", httpRouteRes.err, ingressRes.err)
 }
 
 func finishRouteOperation(route *entity.Route, status string) (*entity.Route, error) {
@@ -380,7 +388,7 @@ func resolveDeleteRouteResult(
 
 		if isDeleteFailure(httpRouteErr) || isDeleteFailure(ingressErr) {
 			logger.Error(RouteDeleteFailed, status)
-			return paasErrors.NewInternalError(fmt.Errorf("%s", status))
+			return dualModeDeleteError(httpRouteErr, ingressErr)
 		}
 
 		logger.Info("Route delete completed: %s", status)
@@ -406,10 +414,23 @@ func resolveSingleResourceDeleteResult(resourceName string, err error) error {
 	}
 	if isDeleteFailure(err) {
 		logger.Error(RouteDeleteFailed, status)
-		return paasErrors.NewInternalError(fmt.Errorf("%s", status))
+		return fmt.Errorf("%s: error: %w", resourceName, err)
 	}
 	logger.Warn(RouteDeleteFailed, status)
 	return err
+}
+
+func dualModeDeleteError(httpRouteErr, ingressErr error) error {
+	httpFailed := isDeleteFailure(httpRouteErr)
+	ingressFailed := isDeleteFailure(ingressErr)
+
+	if httpFailed && ingressFailed {
+		return fmt.Errorf("httproute: error: %w, ingress: error: %w", httpRouteErr, ingressErr)
+	}
+	if httpFailed {
+		return fmt.Errorf("httproute: error: %w", httpRouteErr)
+	}
+	return fmt.Errorf("ingress: error: %w", ingressErr)
 }
 
 func newRouteDeleteNotFoundError(routeName, status string) error {

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -117,7 +117,7 @@ func dualModeRouteError(httpRouteRes, ingressRes routeResourceResult) error {
 	}
 
 	failedErr := cmp.Or(httpRouteRes.err, ingressRes.err)
-	status := formatDualModeRouteStatus(httpRouteRes, ingressRes)
+	status := formatDualModeRouteStatusSummary(httpRouteRes, ingressRes)
 	return fmt.Errorf("%s%s: %w", status, dualModeRouteUpdateHint, failedErr)
 }
 
@@ -140,9 +140,23 @@ func formatDualModeRouteStatus(httpRouteRes, ingressRes routeResourceResult) str
 	)
 }
 
+func formatDualModeRouteStatusSummary(httpRouteRes, ingressRes routeResourceResult) string {
+	return fmt.Sprintf("%s, %s",
+		formatRouteResourceStatusSummary("httproute", httpRouteRes),
+		formatRouteResourceStatusSummary("ingress", ingressRes),
+	)
+}
+
 func formatRouteResourceStatus(name string, res routeResourceResult) string {
 	if res.err != nil {
 		return fmt.Sprintf("%s: error: %v", name, res.err)
+	}
+	return fmt.Sprintf("%s: %s", name, res.status)
+}
+
+func formatRouteResourceStatusSummary(name string, res routeResourceResult) string {
+	if res.err != nil {
+		return fmt.Sprintf("%s: error", name)
 	}
 	return fmt.Sprintf("%s: %s", name, res.status)
 }

--- a/service/internal/kubernetes/route_test.go
+++ b/service/internal/kubernetes/route_test.go
@@ -756,7 +756,6 @@ func Test_DeleteRoute_DualMode_HTTPRouteDeleted_IngressDeleteError_ReturnsFullSt
 	err = kubeClient.DeleteRoute(ctx, testIngress, testNamespace1)
 	assertions.Error(err)
 	assertions.True(paasErrors.IsInternalError(err))
-	assertions.Contains(err.Error(), "httproute: deleted")
 	assertions.Contains(err.Error(), "ingress: error:")
 	assertions.Contains(err.Error(), "ingress delete failed")
 
@@ -781,7 +780,6 @@ func Test_DeleteRoute_DualMode_HTTPRouteDeleteError_IngressDeleted_ReturnsFullSt
 	assertions.True(paasErrors.IsInternalError(err))
 	assertions.Contains(err.Error(), "httproute: error:")
 	assertions.Contains(err.Error(), "httproute delete failed")
-	assertions.Contains(err.Error(), "ingress: deleted")
 
 	_, err = k8sClient.NetworkingV1().Ingresses(testNamespace1).Get(ctx, testIngress, metav1.GetOptions{})
 	assertions.True(paasErrors.IsNotFound(err))

--- a/service/internal/kubernetes/route_test.go
+++ b/service/internal/kubernetes/route_test.go
@@ -17,6 +17,7 @@ import (
 	paasErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/version"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	"k8s.io/client-go/kubernetes/fake"
@@ -566,6 +567,106 @@ func Test_CreateRoute_DualMode_BothFailed_ReturnsFullStatusError(t *testing.T) {
 	assertions.Contains(err.Error(), "ingress: error:")
 	assertions.Contains(err.Error(), "ingress create failed")
 	assertions.NotContains(err.Error(), "try using Update endpoint")
+}
+
+func Test_dualModeRouteError_BothSucceeded_ReturnsNil(t *testing.T) {
+	err := dualModeRouteError(
+		routeResourceResult{status: routeStatusCreated},
+		routeResourceResult{status: routeStatusCreated},
+	)
+	require.NoError(t, err)
+}
+
+func Test_dualModeRouteError_ShowsHintOnCreatePartialFailure(t *testing.T) {
+	err := dualModeRouteError(
+		routeResourceResult{status: routeStatusCreated},
+		routeResourceResult{status: routeStatusCreated, err: paasErrors.NewInternalError(fmt.Errorf("ingress create failed"))},
+	)
+	require.Contains(t, err.Error(), "try using Update endpoint")
+}
+
+func Test_CreateRoute_DualMode_BothAlreadyExists_ReturnsAlreadyExistsError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	gwClient := gatewayclientfake.NewSimpleClientset()
+	gwClient.PrependReactor("create", "httproutes", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewAlreadyExists(
+			schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "httproutes"}, testIngress)
+	})
+	kubeClientSet := fake.NewClientset()
+	kubeClientSet.PrependReactor("create", "ingresses", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewAlreadyExists(schema.GroupResource{Resource: "ingresses"}, testIngress)
+	})
+	kubeClient, err := NewKubernetesClientBuilder().
+		WithNamespace(testNamespace1).
+		WithClient(&backend.KubernetesApi{
+			KubernetesInterface:  kubeClientSet,
+			CertmanagerInterface: &certClient.Clientset{},
+			GatewayInterface:     gwClient,
+		}).
+		WithGatewaySystemType(LegacyIngress + "," + GatewayApiDefault).
+		Build()
+	require.NoError(t, err)
+	kubeClient.UseNetworkingV1Ingress = true
+
+	_, err = kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.Error(err)
+	assertions.True(paasErrors.IsAlreadyExists(err))
+	assertions.False(paasErrors.IsInternalError(err))
+	assertions.Contains(err.Error(), "httproute: error:")
+	assertions.Contains(err.Error(), "already exists")
+	assertions.Contains(err.Error(), "ingress: error:")
+	assertions.NotContains(err.Error(), "try using Update endpoint")
+}
+
+func Test_CreateRoute_DualMode_AlreadyExistsAndInternalError_ReturnsAlreadyExistsError(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	gwClient := gatewayclientfake.NewSimpleClientset()
+	gwClient.PrependReactor("create", "httproutes", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewAlreadyExists(
+			schema.GroupResource{Group: "gateway.networking.k8s.io", Resource: "httproutes"}, testIngress)
+	})
+	kubeClientSet := fake.NewClientset()
+	kubeClientSet.PrependReactor("create", "ingresses", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewInternalError(fmt.Errorf("ingress create failed"))
+	})
+	kubeClient, err := NewKubernetesClientBuilder().
+		WithNamespace(testNamespace1).
+		WithClient(&backend.KubernetesApi{
+			KubernetesInterface:  kubeClientSet,
+			CertmanagerInterface: &certClient.Clientset{},
+			GatewayInterface:     gwClient,
+		}).
+		WithGatewaySystemType(LegacyIngress + "," + GatewayApiDefault).
+		Build()
+	require.NoError(t, err)
+	kubeClient.UseNetworkingV1Ingress = true
+
+	_, err = kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.Error(err)
+	assertions.True(paasErrors.IsAlreadyExists(err))
+	assertions.Contains(err.Error(), "httproute: error:")
+	assertions.Contains(err.Error(), "ingress: error:")
+	assertions.Contains(err.Error(), "ingress create failed")
+	assertions.NotContains(err.Error(), "try using Update endpoint")
+}
+
+func Test_CreateRoute_DualMode_PartialCreate_IngressAlreadyExists_ReturnsAlreadyExistsWithHint(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+	kubeClient, k8sClient, _ := newDualModeKubeClient(t)
+
+	k8sClient.PrependReactor("create", "ingresses", func(action kube_test.Action) (bool, runtime.Object, error) {
+		return true, nil, paasErrors.NewAlreadyExists(schema.GroupResource{Resource: "ingresses"}, testIngress)
+	})
+
+	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
+	assertions.Error(err)
+	assertions.True(paasErrors.IsAlreadyExists(err))
+	assertions.Contains(err.Error(), "httproute: created")
+	assertions.Contains(err.Error(), "ingress: error:")
+	assertions.Contains(err.Error(), "try using Update endpoint")
 }
 
 func Test_CreateRoute_DualMode_HTTPRouteFailed_IngressCreated_ReturnsPartialCreateError(t *testing.T) {

--- a/service/internal/kubernetes/route_test.go
+++ b/service/internal/kubernetes/route_test.go
@@ -524,7 +524,7 @@ func Test_CreateRoute_DualMode_HTTPRouteCreated_IngressFailed_ReturnsPartialCrea
 	assertions.Error(err)
 	assertions.True(paasErrors.IsInternalError(err))
 	assertions.Contains(err.Error(), "httproute: created")
-	assertions.Contains(err.Error(), "ingress: error:")
+	assertions.Contains(err.Error(), "ingress: error")
 	assertions.Contains(err.Error(), "try using Update endpoint")
 
 	httpRouteList, err := gwClient.GatewayV1().HTTPRoutes(testNamespace1).List(ctx, metav1.ListOptions{})
@@ -665,7 +665,7 @@ func Test_CreateRoute_DualMode_PartialCreate_IngressAlreadyExists_ReturnsAlready
 	assertions.Error(err)
 	assertions.True(paasErrors.IsAlreadyExists(err))
 	assertions.Contains(err.Error(), "httproute: created")
-	assertions.Contains(err.Error(), "ingress: error:")
+	assertions.Contains(err.Error(), "ingress: error")
 	assertions.Contains(err.Error(), "try using Update endpoint")
 }
 
@@ -692,7 +692,7 @@ func Test_CreateRoute_DualMode_HTTPRouteFailed_IngressCreated_ReturnsPartialCrea
 	_, err = kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
 	assertions.Error(err)
 	assertions.True(paasErrors.IsInternalError(err))
-	assertions.Contains(err.Error(), "httproute: error:")
+	assertions.Contains(err.Error(), "httproute: error")
 	assertions.Contains(err.Error(), "ingress: created")
 	assertions.Contains(err.Error(), "try using Update endpoint")
 
@@ -737,7 +737,7 @@ func Test_UpdateOrCreateRoute_DualMode_AfterPartialCreate_CreatesMissingIngress(
 	_, err := kubeClient.CreateRoute(ctx, dualModeTestRoute(), testNamespace1)
 	assertions.Error(err)
 	assertions.Contains(err.Error(), "httproute: created")
-	assertions.Contains(err.Error(), "ingress: error:")
+	assertions.Contains(err.Error(), "ingress: error")
 
 	httpRouteList, err := gwClient.GatewayV1().HTTPRoutes(testNamespace1).List(ctx, metav1.ListOptions{})
 	assertions.NoError(err)
@@ -788,7 +788,7 @@ func Test_UpdateOrCreateRoute_DualMode_HTTPRouteUpdated_IngressUpdateError_Retur
 	assertions.Error(err)
 	assertions.True(paasErrors.IsInternalError(err))
 	assertions.Contains(err.Error(), "httproute: updated")
-	assertions.Contains(err.Error(), "ingress: error:")
+	assertions.Contains(err.Error(), "ingress: error")
 	assertions.Contains(err.Error(), "ingress update failed")
 	assertions.Contains(err.Error(), "try using Update endpoint")
 
@@ -1463,4 +1463,97 @@ func Test_UpdateOrCreateRoute_DualMode_SetsIgnoreAnnotationOnIngressUpdate(t *te
 	ingress, err := k8sClient.NetworkingV1().Ingresses(testNamespace1).Get(ctx, testIngress, metav1.GetOptions{})
 	assertions.NoError(err)
 	assertions.Equal("true", ingress.Annotations[IgnoreApiConverterAnnotation])
+}
+
+func Test_dualModeRouteError_NoErrorDuplication(t *testing.T) {
+	t.Parallel()
+	assertions := require.New(t)
+
+	tests := []struct {
+		name           string
+		httpRouteRes   routeResourceResult
+		ingressRes     routeResourceResult
+		wantErrContain string
+		wantNoContain  string
+	}{
+		{
+			name: "HTTPRoute success, Ingress failed - no duplication",
+			httpRouteRes: routeResourceResult{
+				route:  &entity.Route{Metadata: entity.Metadata{Name: "test"}},
+				status: routeStatusCreated,
+				err:    nil,
+			},
+			ingressRes: routeResourceResult{
+				route:  nil,
+				status: "",
+				err:    fmt.Errorf("ingress creation failed"),
+			},
+			wantErrContain: "httproute: created, ingress: error - try using Update endpoint: ingress creation failed",
+			wantNoContain:  "ingress creation failed - try using Update endpoint: ingress creation failed",
+		},
+		{
+			name: "HTTPRoute failed, Ingress success - no duplication",
+			httpRouteRes: routeResourceResult{
+				route:  nil,
+				status: "",
+				err:    fmt.Errorf("httproute creation failed"),
+			},
+			ingressRes: routeResourceResult{
+				route:  &entity.Route{Metadata: entity.Metadata{Name: "test"}},
+				status: routeStatusCreated,
+				err:    nil,
+			},
+			wantErrContain: "httproute: error, ingress: created - try using Update endpoint: httproute creation failed",
+			wantNoContain:  "httproute creation failed - try using Update endpoint: httproute creation failed",
+		},
+		{
+			name: "Both failed - both errors wrapped",
+			httpRouteRes: routeResourceResult{
+				route:  nil,
+				status: "",
+				err:    fmt.Errorf("httproute error"),
+			},
+			ingressRes: routeResourceResult{
+				route:  nil,
+				status: "",
+				err:    fmt.Errorf("ingress error"),
+			},
+			wantErrContain: "httproute: error: httproute error, ingress: error: ingress error",
+			wantNoContain:  "",
+		},
+		{
+			name: "Both success - no error",
+			httpRouteRes: routeResourceResult{
+				route:  &entity.Route{Metadata: entity.Metadata{Name: "test"}},
+				status: routeStatusCreated,
+				err:    nil,
+			},
+			ingressRes: routeResourceResult{
+				route:  &entity.Route{Metadata: entity.Metadata{Name: "test"}},
+				status: routeStatusCreated,
+				err:    nil,
+			},
+			wantErrContain: "",
+			wantNoContain:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := dualModeRouteError(tt.httpRouteRes, tt.ingressRes)
+
+			if tt.wantErrContain == "" {
+				assertions.NoError(err)
+				return
+			}
+
+			assertions.Error(err)
+			assertions.Contains(err.Error(), tt.wantErrContain)
+
+			if tt.wantNoContain != "" {
+				assertions.NotContains(err.Error(), tt.wantNoContain, "error message should not contain duplicated error text")
+			}
+		})
+	}
 }

--- a/service/internal/kubernetes/route_test.go
+++ b/service/internal/kubernetes/route_test.go
@@ -582,6 +582,7 @@ func Test_dualModeRouteError_ShowsHintOnCreatePartialFailure(t *testing.T) {
 		routeResourceResult{status: routeStatusCreated},
 		routeResourceResult{status: routeStatusCreated, err: paasErrors.NewInternalError(fmt.Errorf("ingress create failed"))},
 	)
+	require.Error(t, err)
 	require.Contains(t, err.Error(), "try using Update endpoint")
 }
 


### PR DESCRIPTION
# What does this MR do?

This MR fixes error formatting for dual mode in CreateRoute. This is done because we expect to have the same default errors as in single mode