### PR TITLE
fix: change logic for get endpoints

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -7,6 +7,31 @@
 
 Golang implementation of paas agnostic access to the resources of Openshift/Kubernetes
 
+---
+
+> ## IMPORTANT: Route read operations in dual mode (`GATEWAY_SYSTEM_TYPE`)
+>
+> When `GATEWAY_SYSTEM_TYPE` contains `gateway-api-default` — **including dual mode**
+> (`legacy-ingress,gateway-api-default` or `gateway-api-default,legacy-ingress`) —
+> the following **read** operations behave exactly as if only Gateway API (HTTPRoute) mode were enabled:
+>
+> | Operation | Read source |
+> |-----------|-------------|
+> | `GetRoute` | `HTTPRoute` only (not Ingress) |
+> | `GetRouteList` | `HTTPRoute` only (not Ingress) |
+> | `WatchRoutes` | `HTTPRoute` watch only (not Ingress) |
+> | `GetBadRouteLists` | empty list (Ingress bad-route tracking is not used in this mode) |
+>
+> The response format is unchanged: clients still receive `entity.Route`.
+>
+> **Write operations are not affected by this rule.** In dual mode, `CreateRoute`, `UpdateRoute`, and
+> `DeleteRoute` still operate on **both** HTTPRoute and Ingress when both values are present in
+> `GATEWAY_SYSTEM_TYPE`.
+>
+> Configure `GATEWAY_SYSTEM_TYPE` via the `gateway.system.type` property when building the client.
+
+---
+
 <!-- TOC -->
       * [Supported operations:](#supported-operations)
       * [Usage:](#usage)

--- a/service/internal/kubernetes/gateway_system_test.go
+++ b/service/internal/kubernetes/gateway_system_test.go
@@ -1,0 +1,54 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGatewaySystem_TypeCheckedByContains_NotOrder(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                   string
+		typ                    string
+		wantGatewayAPI         bool
+		wantIngress            bool
+		wantBothGatewaySystems bool
+	}{
+		{name: "legacy only", typ: LegacyIngress, wantGatewayAPI: false, wantIngress: true, wantBothGatewaySystems: false},
+		{name: "gateway api only", typ: GatewayApiDefault, wantGatewayAPI: true, wantIngress: false, wantBothGatewaySystems: false},
+		{
+			name:                   "both legacy first",
+			typ:                    LegacyIngress + "," + GatewayApiDefault,
+			wantGatewayAPI:         true,
+			wantIngress:            true,
+			wantBothGatewaySystems: true,
+		},
+		{
+			name:                   "both gateway api first",
+			typ:                    GatewayApiDefault + "," + LegacyIngress,
+			wantGatewayAPI:         true,
+			wantIngress:            true,
+			wantBothGatewaySystems: true,
+		},
+		{
+			name:                   "both with spaces",
+			typ:                    GatewayApiDefault + ", " + LegacyIngress,
+			wantGatewayAPI:         true,
+			wantIngress:            true,
+			wantBothGatewaySystems: true,
+		},
+		{name: "empty defaults to legacy ingress", typ: "", wantGatewayAPI: false, wantIngress: true, wantBothGatewaySystems: false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			gs := GatewaySystem{Type: tc.typ}
+			require.Equal(t, tc.wantGatewayAPI, gs.IsGatewayAPIEnabled())
+			require.Equal(t, tc.wantIngress, gs.IsIngressEnabled())
+			require.Equal(t, tc.wantBothGatewaySystems, gs.IsBothGatewaySystemsEnabled())
+		})
+	}
+}

--- a/service/internal/kubernetes/kubeService_test.go
+++ b/service/internal/kubernetes/kubeService_test.go
@@ -269,12 +269,15 @@ func testGetRouteListWithLabelsAndAnnotationsByGatewayType(t *testing.T) {
 	t.Run(GatewayApiDefault, func(t *testing.T) {
 		testGetRouteListWithLabelsAndAnnotationsGatewayAPI(t, GatewayApiDefault)
 	})
+	t.Run(GatewayApiDefault+"-empty-list-without-httproutes", func(t *testing.T) {
+		testGetRouteListWithLabelsAndAnnotationsGatewayAPI_EmptyWhenNoHTTPRoutes(t, GatewayApiDefault)
+	})
 	for _, gatewaySystemType := range []string{
 		LegacyIngress + "," + GatewayApiDefault,
 		GatewayApiDefault + "," + LegacyIngress,
 	} {
 		t.Run(gatewaySystemType, func(t *testing.T) {
-			testGetRouteListWithLabelsAndAnnotationsGatewayAPI(t, gatewaySystemType)
+			testGetRouteListWithLabelsAndAnnotationsGatewayAPI_DualModeIgnoresIngress(t, gatewaySystemType)
 		})
 		t.Run(gatewaySystemType+"-empty-list-without-httproutes", func(t *testing.T) {
 			testGetRouteListWithLabelsAndAnnotationsGatewayAPI_EmptyWhenNoHTTPRoutes(t, gatewaySystemType)
@@ -303,7 +306,7 @@ func testGetRouteListWithLabelsAndAnnotationsLegacyIngress(t *testing.T) {
 
 	clientset := fake.NewClientset(resource1, resource2)
 	kubeClient := &Kubernetes{
-		client:        &backend.KubernetesApi{KubernetesInterface: clientset, CertmanagerInterface: &certClient.Clientset{}},
+		client:        newBuildTestKubernetesAPI(clientset, gatewayclientfake.NewSimpleClientset()),
 		WatchExecutor: testWatchExecutor,
 		namespace:     testNamespace1,
 		Cache:         cache.NewTestResourcesCache(),
@@ -347,11 +350,8 @@ func testGetRouteListWithLabelsAndAnnotationsGatewayAPI(t *testing.T, gatewaySys
 	resourceName2 := "test-resource-2"
 	httpRoute2 := createTestHTTPRoute(resourceName2, testNamespace1, nil, resourceAnnotationMap2)
 
-	ingress1 := createTestRoute(resourceName1, testNamespace1, nil, resourceAnnotationMap1)
-	ingress2 := createTestRoute(resourceName2, testNamespace1, nil, resourceAnnotationMap2)
-
-	kubeClientSet := fake.NewClientset(ingress1, ingress2)
 	gwClient := gatewayclientfake.NewSimpleClientset(httpRoute1, httpRoute2)
+	kubeClientSet := fake.NewClientset()
 	kubeClient := &Kubernetes{
 		client:        newBuildTestKubernetesAPI(kubeClientSet, gwClient),
 		WatchExecutor: testWatchExecutor,
@@ -384,16 +384,77 @@ func testGetRouteListWithLabelsAndAnnotationsGatewayAPI(t *testing.T, gatewaySys
 	r.Equal(resourceName1, foundResourceInCache.Name)
 }
 
-func testGetRouteListWithLabelsAndAnnotationsGatewayAPI_EmptyWhenNoHTTPRoutes(t *testing.T, gatewaySystemType string) {
+func testGetRouteListWithLabelsAndAnnotationsGatewayAPI_DualModeIgnoresIngress(t *testing.T, gatewaySystemType string) {
 	r := require.New(t)
 	gatewaySystem := GatewaySystem{Type: gatewaySystemType}
 	r.True(gatewaySystem.IsGatewayAPIEnabled())
 	r.True(gatewaySystem.IsIngressEnabled())
 	ctx := context.Background()
+	testWatchExecutor := newFakeWatchExecutor()
 
-	ingress1 := createTestRoute("test-resource-1", testNamespace1, nil, map[string]string{annotationKey1: annotationValue1})
+	annotationMap := map[string]string{annotationKey1: annotationValue1, annotationKey2: annotationValue2}
+	httpRouteName := "httproute-resource-1"
+	ingressName := "ingress-resource-1"
+
+	httpRoute1 := createTestHTTPRoute(httpRouteName, testNamespace1, nil, annotationMap)
+	httpRoute2 := createTestHTTPRoute("httproute-resource-2", testNamespace1, nil, map[string]string{
+		annotationKey2: annotationValue2,
+		annotationKey3: annotationValue3,
+	})
+	ingress1 := createTestRoute(ingressName, testNamespace1, nil, annotationMap)
+	ingress2 := createTestRoute("ingress-resource-2", testNamespace1, nil, map[string]string{
+		annotationKey2: annotationValue2,
+		annotationKey3: annotationValue3,
+	})
+
 	kubeClient := &Kubernetes{
-		client:        newBuildTestKubernetesAPI(fake.NewClientset(ingress1), gatewayclientfake.NewSimpleClientset()),
+		client: newBuildTestKubernetesAPI(
+			fake.NewClientset(ingress1, ingress2),
+			gatewayclientfake.NewSimpleClientset(httpRoute1, httpRoute2),
+		),
+		WatchExecutor: testWatchExecutor,
+		namespace:     testNamespace1,
+		Cache:         cache.NewTestResourcesCache(cache.HttpRouteCache),
+		BadResources:  &BadResources{Routes: NewBadRoutes()},
+		GatewaySystem: gatewaySystem,
+	}
+
+	foundResources, err := kubeClient.GetRouteList(ctx, testNamespace1, filter.Meta{Annotations: annotationMap})
+	r.NoError(err)
+	r.Len(foundResources, 1)
+	r.Equal(httpRouteName, foundResources[0].Name, "dual-mode must return HTTPRoute, not Ingress with name %q", ingressName)
+
+	badRoutes, err := kubeClient.GetBadRouteLists(ctx)
+	r.NoError(err)
+	r.Empty(badRoutes)
+
+	gwClientForCache := gatewayclientfake.NewSimpleClientset()
+	gwClientForCache.PrependReactor("get", "httproutes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("error test")
+	})
+	kubeClient.client = newBuildTestKubernetesAPI(fake.NewClientset(ingress1, ingress2), gwClientForCache)
+	ok, err := kubeClient.Cache.HTTPRoute.Set(ctx, *entity.WrapHTTPRoute(httpRoute1))
+	r.True(ok)
+	r.NoError(err)
+	foundResourceInCache, err := kubeClient.GetRoute(ctx, httpRouteName, testNamespace1)
+	r.NoError(err)
+	r.Equal(httpRouteName, foundResourceInCache.Name)
+}
+
+func testGetRouteListWithLabelsAndAnnotationsGatewayAPI_EmptyWhenNoHTTPRoutes(t *testing.T, gatewaySystemType string) {
+	r := require.New(t)
+	gatewaySystem := GatewaySystem{Type: gatewaySystemType}
+	r.True(gatewaySystem.IsGatewayAPIEnabled(),
+		"GetRouteList must read HTTPRoutes when GATEWAY_SYSTEM_TYPE contains %q", GatewayApiDefault)
+	ctx := context.Background()
+
+	var k8sObjects []runtime.Object
+	if gatewaySystem.IsIngressEnabled() {
+		ingress1 := createTestRoute("test-resource-1", testNamespace1, nil, map[string]string{annotationKey1: annotationValue1})
+		k8sObjects = append(k8sObjects, ingress1)
+	}
+	kubeClient := &Kubernetes{
+		client:        newBuildTestKubernetesAPI(fake.NewClientset(k8sObjects...), gatewayclientfake.NewSimpleClientset()),
 		namespace:     testNamespace1,
 		Cache:         cache.NewTestResourcesCache(),
 		BadResources:  &BadResources{Routes: NewBadRoutes()},

--- a/service/internal/kubernetes/kubeService_test.go
+++ b/service/internal/kubernetes/kubeService_test.go
@@ -142,7 +142,7 @@ func TestGetConfigMapListWithLabelsAndAnnotations(t *testing.T) {
 }
 
 func TestGetRouteListWithLabelsAndAnnotations(t *testing.T) {
-	testGetResourceListWithLabelsAndAnnotations(t, "route")
+	testGetRouteListWithLabelsAndAnnotationsByGatewayType(t)
 }
 
 func TestGetCertificateListWithLabelsAndAnnotations(t *testing.T) {
@@ -181,9 +181,9 @@ func testGetResourceListWithLabelsAndAnnotations(t *testing.T, resType string) {
 		CertmanagerInterface: &mock.CmClientset{},
 	}
 	var badResources = BadResources{NewBadRoutes()}
-	cache := cache.NewTestResourcesCache()
+	resourcesCache := cache.NewTestResourcesCache()
 	kubeClient := &Kubernetes{client: clientset, WatchExecutor: testWatchExecutor, namespace: testNamespace1,
-		Cache: cache, BadResources: &badResources}
+		Cache: resourcesCache, BadResources: &badResources}
 
 	var annotationMap = make(map[string]string)
 	annotationMap[annotationKey1] = annotationValue1
@@ -196,10 +196,10 @@ func testGetResourceListWithLabelsAndAnnotations(t *testing.T, resType string) {
 		r.True(So(err, ShouldBeNil))
 		r.Equal(1, len(foundResources), "expect 1 service to be found")
 		r.Equal(foundResources[0].Name, resourceName1, "invalid service name")
-
+		// todo add tests with kubeClient.client.System.Type
 		//Broke client and test cache
 		kubeClient.client = badClientset
-		ok, err := cache.Services.Set(ctx, *entity.NewService(resource1.(*v1.Service)))
+		ok, err := resourcesCache.Services.Set(ctx, *entity.NewService(resource1.(*v1.Service)))
 		r.True(ok)
 		r.NoError(err)
 		foundResourceInCache, err := kubeClient.GetService(ctx, resourceName1, testNamespace1)
@@ -221,7 +221,7 @@ func testGetResourceListWithLabelsAndAnnotations(t *testing.T, resType string) {
 		r.Equal(foundResources[0].Name, resourceName1, "invalid service name")
 		//Broke client and test cache
 		kubeClient.client = badClientset
-		ok, err := cache.Secrets.Set(ctx, *entity.NewSecret(resource1.(*v1.Secret)))
+		ok, err := resourcesCache.Secrets.Set(ctx, *entity.NewSecret(resource1.(*v1.Secret)))
 		r.True(ok)
 		r.NoError(err)
 		foundResourceInCache, err := kubeClient.GetSecret(ctx, resourceName1, testNamespace1)
@@ -235,23 +235,10 @@ func testGetResourceListWithLabelsAndAnnotations(t *testing.T, resType string) {
 		r.Equal(foundResources[0].Name, resourceName1, "invalid service name")
 		//Broke client and test cache
 		kubeClient.client = badClientset
-		ok, err := cache.ConfigMaps.Set(ctx, *entity.NewConfigMap(resource1.(*v1.ConfigMap)))
+		ok, err := resourcesCache.ConfigMaps.Set(ctx, *entity.NewConfigMap(resource1.(*v1.ConfigMap)))
 		r.True(ok)
 		r.NoError(err)
 		foundResourceInCache, err := kubeClient.GetConfigMap(ctx, resourceName1, testNamespace1)
-		r.Nil(err)
-		r.Equal(foundResourceInCache.Name, resourceName1, "invalid service name")
-	case "route":
-		foundResources, err := kubeClient.GetRouteList(ctx, testNamespace1, filter.Meta{Annotations: annotationMap})
-		r.Nil(err)
-		r.Equal(1, len(foundResources), "expect 1 route to be found")
-		r.Equal(foundResources[0].Name, resourceName1, "invalid service name")
-		//Broke client and test cache
-		kubeClient.client = badClientset
-		ok, err := cache.Ingresses.Set(ctx, *entity.RouteFromIngress(resource1.(*v1beta1.Ingress)))
-		r.True(ok)
-		r.NoError(err)
-		foundResourceInCache, err := kubeClient.GetRoute(ctx, resourceName1, testNamespace1)
 		r.Nil(err)
 		r.Equal(foundResourceInCache.Name, resourceName1, "invalid service name")
 	case "certificate":
@@ -274,6 +261,149 @@ func testGetResourceListWithLabelsAndAnnotations(t *testing.T, resType string) {
 	default:
 		r.False(false, "unsupported type "+resType)
 	}
+}
+
+func testGetRouteListWithLabelsAndAnnotationsByGatewayType(t *testing.T) {
+	t.Run(LegacyIngress, func(t *testing.T) {
+		testGetRouteListWithLabelsAndAnnotationsLegacyIngress(t)
+	})
+	t.Run(GatewayApiDefault, func(t *testing.T) {
+		testGetRouteListWithLabelsAndAnnotationsGatewayAPI(t, GatewayApiDefault)
+	})
+	for _, gatewaySystemType := range []string{
+		LegacyIngress + "," + GatewayApiDefault,
+		GatewayApiDefault + "," + LegacyIngress,
+	} {
+		t.Run(gatewaySystemType, func(t *testing.T) {
+			testGetRouteListWithLabelsAndAnnotationsGatewayAPI(t, gatewaySystemType)
+		})
+		t.Run(gatewaySystemType+"-empty-list-without-httproutes", func(t *testing.T) {
+			testGetRouteListWithLabelsAndAnnotationsGatewayAPI_EmptyWhenNoHTTPRoutes(t, gatewaySystemType)
+		})
+	}
+}
+
+func testGetRouteListWithLabelsAndAnnotationsLegacyIngress(t *testing.T) {
+	r := require.New(t)
+	ctx := context.Background()
+	testWatchExecutor := newFakeWatchExecutor()
+
+	resourceAnnotationMap1 := map[string]string{
+		annotationKey1: annotationValue1,
+		annotationKey2: annotationValue2,
+	}
+	resourceName1 := "test-resource-1"
+	resource1 := createTestRoute(resourceName1, testNamespace1, nil, resourceAnnotationMap1)
+
+	resourceAnnotationMap2 := map[string]string{
+		annotationKey2: annotationValue2,
+		annotationKey3: annotationValue3,
+	}
+	resourceName2 := "test-resource-2"
+	resource2 := createTestRoute(resourceName2, testNamespace1, nil, resourceAnnotationMap2)
+
+	clientset := fake.NewClientset(resource1, resource2)
+	kubeClient := &Kubernetes{
+		client:        &backend.KubernetesApi{KubernetesInterface: clientset, CertmanagerInterface: &certClient.Clientset{}},
+		WatchExecutor: testWatchExecutor,
+		namespace:     testNamespace1,
+		Cache:         cache.NewTestResourcesCache(),
+		BadResources:  &BadResources{Routes: NewBadRoutes()},
+		GatewaySystem: GatewaySystem{Type: LegacyIngress},
+	}
+	annotationMap := map[string]string{annotationKey1: annotationValue1, annotationKey2: annotationValue2}
+
+	foundResources, err := kubeClient.GetRouteList(ctx, testNamespace1, filter.Meta{Annotations: annotationMap})
+	r.NoError(err)
+	r.Len(foundResources, 1)
+	r.Equal(resourceName1, foundResources[0].Name)
+
+	kubeClient.client = &backend.KubernetesApi{KubernetesInterface: &mock.KubeClientset{}, CertmanagerInterface: &mock.CmClientset{}}
+	ok, err := kubeClient.Cache.Ingresses.Set(ctx, *entity.RouteFromIngress(resource1))
+	r.True(ok)
+	r.NoError(err)
+	foundResourceInCache, err := kubeClient.GetRoute(ctx, resourceName1, testNamespace1)
+	r.NoError(err)
+	r.Equal(resourceName1, foundResourceInCache.Name)
+}
+
+func testGetRouteListWithLabelsAndAnnotationsGatewayAPI(t *testing.T, gatewaySystemType string) {
+	r := require.New(t)
+	r.True(GatewaySystem{Type: gatewaySystemType}.IsGatewayAPIEnabled(),
+		"GetRouteList must use HTTPRoutes when GATEWAY_SYSTEM_TYPE contains %q", GatewayApiDefault)
+	ctx := context.Background()
+	testWatchExecutor := newFakeWatchExecutor()
+
+	resourceAnnotationMap1 := map[string]string{
+		annotationKey1: annotationValue1,
+		annotationKey2: annotationValue2,
+	}
+	resourceName1 := "test-resource-1"
+	httpRoute1 := createTestHTTPRoute(resourceName1, testNamespace1, nil, resourceAnnotationMap1)
+
+	resourceAnnotationMap2 := map[string]string{
+		annotationKey2: annotationValue2,
+		annotationKey3: annotationValue3,
+	}
+	resourceName2 := "test-resource-2"
+	httpRoute2 := createTestHTTPRoute(resourceName2, testNamespace1, nil, resourceAnnotationMap2)
+
+	ingress1 := createTestRoute(resourceName1, testNamespace1, nil, resourceAnnotationMap1)
+	ingress2 := createTestRoute(resourceName2, testNamespace1, nil, resourceAnnotationMap2)
+
+	kubeClientSet := fake.NewClientset(ingress1, ingress2)
+	gwClient := gatewayclientfake.NewSimpleClientset(httpRoute1, httpRoute2)
+	kubeClient := &Kubernetes{
+		client:        newBuildTestKubernetesAPI(kubeClientSet, gwClient),
+		WatchExecutor: testWatchExecutor,
+		namespace:     testNamespace1,
+		Cache:         cache.NewTestResourcesCache(cache.HttpRouteCache),
+		BadResources:  &BadResources{Routes: NewBadRoutes()},
+		GatewaySystem: GatewaySystem{Type: gatewaySystemType},
+	}
+	annotationMap := map[string]string{annotationKey1: annotationValue1, annotationKey2: annotationValue2}
+
+	foundResources, err := kubeClient.GetRouteList(ctx, testNamespace1, filter.Meta{Annotations: annotationMap})
+	r.NoError(err)
+	r.Len(foundResources, 1)
+	r.Equal(resourceName1, foundResources[0].Name)
+
+	badRoutes, err := kubeClient.GetBadRouteLists(ctx)
+	r.NoError(err)
+	r.Empty(badRoutes)
+
+	gwClientForCache := gatewayclientfake.NewSimpleClientset()
+	gwClientForCache.PrependReactor("get", "httproutes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.New("error test")
+	})
+	kubeClient.client = newBuildTestKubernetesAPI(fake.NewClientset(), gwClientForCache)
+	ok, err := kubeClient.Cache.HTTPRoute.Set(ctx, *entity.WrapHTTPRoute(httpRoute1))
+	r.True(ok)
+	r.NoError(err)
+	foundResourceInCache, err := kubeClient.GetRoute(ctx, resourceName1, testNamespace1)
+	r.NoError(err)
+	r.Equal(resourceName1, foundResourceInCache.Name)
+}
+
+func testGetRouteListWithLabelsAndAnnotationsGatewayAPI_EmptyWhenNoHTTPRoutes(t *testing.T, gatewaySystemType string) {
+	r := require.New(t)
+	gatewaySystem := GatewaySystem{Type: gatewaySystemType}
+	r.True(gatewaySystem.IsGatewayAPIEnabled())
+	r.True(gatewaySystem.IsIngressEnabled())
+	ctx := context.Background()
+
+	ingress1 := createTestRoute("test-resource-1", testNamespace1, nil, map[string]string{annotationKey1: annotationValue1})
+	kubeClient := &Kubernetes{
+		client:        newBuildTestKubernetesAPI(fake.NewClientset(ingress1), gatewayclientfake.NewSimpleClientset()),
+		namespace:     testNamespace1,
+		Cache:         cache.NewTestResourcesCache(),
+		BadResources:  &BadResources{Routes: NewBadRoutes()},
+		GatewaySystem: gatewaySystem,
+	}
+
+	foundResources, err := kubeClient.GetRouteList(ctx, testNamespace1, filter.Meta{Annotations: map[string]string{annotationKey1: annotationValue1}})
+	r.NoError(err)
+	r.Empty(foundResources)
 }
 
 func createTestResource(resType string, name string, namespace string, labels map[string]string,
@@ -333,6 +463,32 @@ func createTestConfigMap(name string, namespace string, labels map[string]string
 	annotations map[string]string) *v1.ConfigMap {
 	return &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: labels,
 		Annotations: annotations}}
+}
+
+func createTestHTTPRoute(name string, namespace string, labels map[string]string,
+	annotations map[string]string) *gatewayv1.HTTPRoute {
+	pathType := gatewayv1.PathMatchPathPrefix
+	pathValue := "/test-path-for-route-" + name
+	port := gatewayv1.PortNumber(8080)
+	hostname := gatewayv1.Hostname("test-host-for-route-" + name)
+	serviceName := gatewayv1.ObjectName("test-service-name-for-route-" + name)
+
+	return &gatewayv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: labels, Annotations: annotations},
+		Spec: gatewayv1.HTTPRouteSpec{
+			Hostnames: []gatewayv1.Hostname{hostname},
+			Rules: []gatewayv1.HTTPRouteRule{{
+				Matches: []gatewayv1.HTTPRouteMatch{{
+					Path: &gatewayv1.HTTPPathMatch{Type: &pathType, Value: &pathValue},
+				}},
+				BackendRefs: []gatewayv1.HTTPBackendRef{{
+					BackendRef: gatewayv1.BackendRef{
+						BackendObjectReference: gatewayv1.BackendObjectReference{Name: serviceName, Port: &port},
+					},
+				}},
+			}},
+		},
+	}
 }
 
 func createTestRoute(name string, namespace string, labels map[string]string,

--- a/service/internal/kubernetes/kubeService_test.go
+++ b/service/internal/kubernetes/kubeService_test.go
@@ -196,7 +196,6 @@ func testGetResourceListWithLabelsAndAnnotations(t *testing.T, resType string) {
 		r.True(So(err, ShouldBeNil))
 		r.Equal(1, len(foundResources), "expect 1 service to be found")
 		r.Equal(foundResources[0].Name, resourceName1, "invalid service name")
-		// todo add tests with kubeClient.client.System.Type
 		//Broke client and test cache
 		kubeClient.client = badClientset
 		ok, err := resourcesCache.Services.Set(ctx, *entity.NewService(resource1.(*v1.Service)))

--- a/service/internal/kubernetes/kubeWatchService_test.go
+++ b/service/internal/kubernetes/kubeWatchService_test.go
@@ -60,6 +60,7 @@ func TestWatchRoutesAddedEvent(t *testing.T) {
 	clientset := &kubernetes.Clientset{}
 	cert_client := &certClient.Clientset{}
 	kubeClient := &Kubernetes{client: &backend.KubernetesApi{KubernetesInterface: clientset, CertmanagerInterface: cert_client}, WatchExecutor: fakeWatchExecutor, namespace: "test-ns",
+		GatewaySystem: GatewaySystem{Type: LegacyIngress},
 		WatchHandlers: NewSharedWatchEventHandlers(fakeWatchExecutor, time.Second,
 			clientset.CoreV1().RESTClient(),
 			cert_client.CertmanagerV1().RESTClient(),
@@ -84,6 +85,7 @@ func TestWatchRoutesAddedEventUseNetworkingV1(t *testing.T) {
 	clientset := &kubernetes.Clientset{}
 	cert_client := &certClient.Clientset{}
 	kubeClient := &Kubernetes{client: &backend.KubernetesApi{KubernetesInterface: clientset, CertmanagerInterface: cert_client}, WatchExecutor: fakeWatchExecutor, namespace: "test-ns",
+		GatewaySystem: GatewaySystem{Type: LegacyIngress},
 		WatchHandlers: NewSharedWatchEventHandlers(fakeWatchExecutor, time.Second,
 			clientset.CoreV1().RESTClient(),
 			cert_client.CertmanagerV1().RESTClient(),

--- a/service/internal/kubernetes/kubeWatchService_test.go
+++ b/service/internal/kubernetes/kubeWatchService_test.go
@@ -106,6 +106,71 @@ func TestWatchRoutesAddedEventUseNetworkingV1(t *testing.T) {
 	})
 }
 
+func TestWatchRoutes_GatewayApiDefault_UsesHTTPRoute(t *testing.T) {
+	testWatchRoutesUsesHTTPRoute(t, GatewayApiDefault)
+}
+
+func TestWatchRoutes_DualMode_UsesHTTPRoute(t *testing.T) {
+	testWatchRoutesUsesHTTPRoute(t, LegacyIngress+","+GatewayApiDefault)
+}
+
+func testWatchRoutesUsesHTTPRoute(t *testing.T, gatewaySystemType string) {
+	r := require.New(t)
+	fakeWatchExecutor := newFakeWatchExecutor()
+	clientset := &kubernetes.Clientset{}
+	cert_client := &certClient.Clientset{}
+	kubeClient := &Kubernetes{
+		client:        &backend.KubernetesApi{KubernetesInterface: clientset, CertmanagerInterface: cert_client},
+		WatchExecutor: fakeWatchExecutor,
+		namespace:     testNamespace1,
+		GatewaySystem: GatewaySystem{Type: gatewaySystemType},
+		WatchHandlers: NewSharedWatchEventHandlers(fakeWatchExecutor, time.Second,
+			clientset.CoreV1().RESTClient(),
+			cert_client.CertmanagerV1().RESTClient(),
+			clientset.NetworkingV1().RESTClient(),
+			clientset.ExtensionsV1beta1().RESTClient()),
+		Cache: cache.NewTestResourcesCache(),
+	}
+	kubeClient.WatchHandlers.WithHTTPRouteV1(fakeWatchExecutor, time.Second, nil)
+
+	watchHandler, err := kubeClient.WatchRoutes(context.Background(), testNamespace1, filter.Meta{})
+	r.NoError(err)
+	r.Equal(types.HTTPRoutes.String(), fakeWatchExecutor.requestedResources)
+
+	verifyWatchHandler(r, func() {
+		httpRoute := createHttpRoute("test-http-route", 1, "1")
+		go fakeWatchExecutor.fakeWatcher.Add(httpRoute)
+		for watchEvent := range watchHandler.Channel {
+			r.Equal("ADDED", watchEvent.Type)
+			expected := entity.WrapHTTPRoute(httpRoute)
+			r.True(So(watchEvent.Object, ShouldResemble, expected))
+			break
+		}
+	})
+}
+
+func TestWatchRoutes_GatewayApiDefault_HTTPRouteNotSupported(t *testing.T) {
+	r := require.New(t)
+	fakeWatchExecutor := newFakeWatchExecutor()
+	clientset := &kubernetes.Clientset{}
+	cert_client := &certClient.Clientset{}
+	kubeClient := &Kubernetes{
+		client:        &backend.KubernetesApi{KubernetesInterface: clientset, CertmanagerInterface: cert_client},
+		WatchExecutor: fakeWatchExecutor,
+		namespace:     testNamespace1,
+		GatewaySystem: GatewaySystem{Type: GatewayApiDefault},
+		WatchHandlers: NewSharedWatchEventHandlers(fakeWatchExecutor, time.Second,
+			clientset.CoreV1().RESTClient(),
+			cert_client.CertmanagerV1().RESTClient(),
+			clientset.NetworkingV1().RESTClient(),
+			clientset.ExtensionsV1beta1().RESTClient()),
+		Cache: cache.NewTestResourcesCache(),
+	}
+
+	_, err := kubeClient.WatchRoutes(context.Background(), testNamespace1, filter.Meta{})
+	r.EqualError(err, "k8s HTTPRoute is not supported")
+}
+
 //func TestWatchRoutesBadAddedEvent(t *testing.T) {
 //	r := require.New(t)
 //	fakeWatchExecutor := newFakeWatchExecutor()

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -374,9 +374,10 @@ func (kube *Kubernetes) GetRoute(ctx context.Context, resourceName string, names
 	if kube.UseNetworkingV1Ingress {
 		return GetWrapper(ctx, resourceName, namespace, kube.getNetworkingV1Client().Ingresses(namespace).Get,
 			kube.Cache.Ingresses, entity.RouteFromIngressNetworkingV1)
+	} else {
+		return GetWrapper(ctx, resourceName, namespace, kube.getExtensionsV1Client().Ingresses(namespace).Get,
+			kube.Cache.Ingresses, entity.RouteFromIngress)
 	}
-	return GetWrapper(ctx, resourceName, namespace, kube.getExtensionsV1Client().Ingresses(namespace).Get,
-		kube.Cache.Ingresses, entity.RouteFromIngress)
 }
 
 func (kube *Kubernetes) DeleteRoute(ctx context.Context, routeName, namespace string) error {
@@ -528,17 +529,18 @@ func (kube *Kubernetes) GetRouteList(ctx context.Context, namespace string, filt
 				}
 				return
 			})
-	}
-	return ListWrapper(ctx, filter, kube.getExtensionsV1Client().Ingresses(namespace).List, kube.Cache.Ingresses,
-		func(listObj *v1beta1.IngressList) (result []entity.Route) {
-			for _, item := range listObj.Items {
-				route := entity.RouteFromIngress(&item)
-				if route != nil {
-					result = append(result, *route)
+	} else {
+		return ListWrapper(ctx, filter, kube.getExtensionsV1Client().Ingresses(namespace).List, kube.Cache.Ingresses,
+			func(listObj *v1beta1.IngressList) (result []entity.Route) {
+				for _, item := range listObj.Items {
+					route := entity.RouteFromIngress(&item)
+					if route != nil {
+						result = append(result, *route)
+					}
 				}
-			}
-			return
-		})
+				return
+			})
+	}
 }
 
 func (kube *Kubernetes) GetHttpRouteList(ctx context.Context, namespace string, filter filter.Meta) ([]entity.HttpRoute, error) {

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -366,9 +366,18 @@ func (kube *Kubernetes) GetRoute(ctx context.Context, resourceName string, names
 	if kube.GatewaySystem.IsGatewayAPIEnabled() {
 		httpRoute, err := GetWrapper(ctx, resourceName, namespace, kube.getGatewayV1Client().HTTPRoutes(namespace).Get,
 			kube.Cache.HTTPRoute, entity.WrapHTTPRoute)
-		if err != nil || httpRoute == nil {
+		if err != nil {
 			return nil, err
 		}
+
+		if httpRoute == nil {
+			return nil, fmt.Errorf("HTTPRoute %s not found in namespace %s", resourceName, namespace)
+		}
+
+		if httpRoute.HTTPRoute == nil {
+			return nil, fmt.Errorf("HTTPRoute %s has nil underlying object in namespace %s", resourceName, namespace)
+		}
+
 		return entity.RouteFromHTTPRoute(httpRoute.HTTPRoute), nil
 	}
 	if kube.UseNetworkingV1Ingress {

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -506,26 +506,16 @@ func (kube *Kubernetes) deleteRouteLegacyIngress(ctx context.Context, routeName,
 
 func (kube *Kubernetes) GetRouteList(ctx context.Context, namespace string, filter filter.Meta) ([]entity.Route, error) {
 	if kube.GatewaySystem.IsGatewayAPIEnabled() {
-		httpRoutes, err := ListWrapper(ctx, filter, kube.getGatewayV1Client().HTTPRoutes(namespace).List, kube.Cache.HTTPRoute,
-			func(listObj *gatewayv1.HTTPRouteList) (result []entity.HttpRoute) {
+		return ListWrapper(ctx, filter, kube.getGatewayV1Client().HTTPRoutes(namespace).List, nil,
+			func(listObj *gatewayv1.HTTPRouteList) (result []entity.Route) {
 				for _, item := range listObj.Items {
-					route := entity.WrapHTTPRoute(&item)
+					route := entity.RouteFromHTTPRoute(&item)
 					if route != nil {
 						result = append(result, *route)
 					}
 				}
 				return
 			})
-		if err != nil {
-			return nil, err
-		}
-		routes := make([]entity.Route, 0, len(httpRoutes))
-		for i := range httpRoutes {
-			if route := entity.RouteFromHTTPRoute(httpRoutes[i].HTTPRoute); route != nil {
-				routes = append(routes, *route)
-			}
-		}
-		return routes, nil
 	}
 	if kube.UseNetworkingV1Ingress {
 		return ListWrapper(ctx, filter, kube.getNetworkingV1Client().Ingresses(namespace).List, kube.Cache.Ingresses,

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -337,14 +337,25 @@ func (kube *Kubernetes) upsertExtensionsV1Ingress(ctx context.Context, route *en
 	return routeResourceResult{route: routeFromIngress, status: routeStatusUpdated}
 }
 
+func (kube *Kubernetes) readRoutesFromGatewayAPI() bool {
+	return kube.GatewaySystem.IsGatewayAPIEnabled()
+}
+
 func (kube *Kubernetes) GetRoute(ctx context.Context, resourceName string, namespace string) (*entity.Route, error) {
+	if kube.readRoutesFromGatewayAPI() {
+		httpRoute, err := GetWrapper(ctx, resourceName, namespace, kube.getGatewayV1Client().HTTPRoutes(namespace).Get,
+			kube.Cache.HTTPRoute, entity.WrapHTTPRoute)
+		if err != nil || httpRoute == nil {
+			return nil, err
+		}
+		return entity.RouteFromHTTPRoute(httpRoute.HTTPRoute), nil
+	}
 	if kube.UseNetworkingV1Ingress {
 		return GetWrapper(ctx, resourceName, namespace, kube.getNetworkingV1Client().Ingresses(namespace).Get,
 			kube.Cache.Ingresses, entity.RouteFromIngressNetworkingV1)
-	} else {
-		return GetWrapper(ctx, resourceName, namespace, kube.getExtensionsV1Client().Ingresses(namespace).Get,
-			kube.Cache.Ingresses, entity.RouteFromIngress)
 	}
+	return GetWrapper(ctx, resourceName, namespace, kube.getExtensionsV1Client().Ingresses(namespace).Get,
+		kube.Cache.Ingresses, entity.RouteFromIngress)
 }
 
 func (kube *Kubernetes) DeleteRoute(ctx context.Context, routeName, namespace string) error {
@@ -450,6 +461,28 @@ func (kube *Kubernetes) deleteRouteLegacyIngress(ctx context.Context, routeName,
 }
 
 func (kube *Kubernetes) GetRouteList(ctx context.Context, namespace string, filter filter.Meta) ([]entity.Route, error) {
+	if kube.readRoutesFromGatewayAPI() {
+		httpRoutes, err := ListWrapper(ctx, filter, kube.getGatewayV1Client().HTTPRoutes(namespace).List, kube.Cache.HTTPRoute,
+			func(listObj *gatewayv1.HTTPRouteList) (result []entity.HttpRoute) {
+				for _, item := range listObj.Items {
+					route := entity.WrapHTTPRoute(&item)
+					if route != nil {
+						result = append(result, *route)
+					}
+				}
+				return
+			})
+		if err != nil {
+			return nil, err
+		}
+		routes := make([]entity.Route, 0, len(httpRoutes))
+		for i := range httpRoutes {
+			if route := entity.RouteFromHTTPRoute(httpRoutes[i].HTTPRoute); route != nil {
+				routes = append(routes, *route)
+			}
+		}
+		return routes, nil
+	}
 	if kube.UseNetworkingV1Ingress {
 		return ListWrapper(ctx, filter, kube.getNetworkingV1Client().Ingresses(namespace).List, kube.Cache.Ingresses,
 			func(listObj *networkingV1.IngressList) (result []entity.Route) {
@@ -461,18 +494,17 @@ func (kube *Kubernetes) GetRouteList(ctx context.Context, namespace string, filt
 				}
 				return
 			})
-	} else {
-		return ListWrapper(ctx, filter, kube.getExtensionsV1Client().Ingresses(namespace).List, kube.Cache.Ingresses,
-			func(listObj *v1beta1.IngressList) (result []entity.Route) {
-				for _, item := range listObj.Items {
-					route := entity.RouteFromIngress(&item)
-					if route != nil {
-						result = append(result, *route)
-					}
-				}
-				return
-			})
 	}
+	return ListWrapper(ctx, filter, kube.getExtensionsV1Client().Ingresses(namespace).List, kube.Cache.Ingresses,
+		func(listObj *v1beta1.IngressList) (result []entity.Route) {
+			for _, item := range listObj.Items {
+				route := entity.RouteFromIngress(&item)
+				if route != nil {
+					result = append(result, *route)
+				}
+			}
+			return
+		})
 }
 
 func (kube *Kubernetes) GetHttpRouteList(ctx context.Context, namespace string, filter filter.Meta) ([]entity.HttpRoute, error) {
@@ -502,15 +534,20 @@ func (kube *Kubernetes) GetGrpcRouteList(ctx context.Context, namespace string, 
 }
 
 func (kube *Kubernetes) GetBadRouteLists(ctx context.Context) (map[string][]string, error) {
+	if kube.readRoutesFromGatewayAPI() {
+		return map[string][]string{}, nil
+	}
 	return kube.BadResources.Routes.ToSliceMap(), nil
 }
 
 func (kube *Kubernetes) WatchRoutes(ctx context.Context, namespace string, metaFilter filter.Meta) (*pmWatch.Handler, error) {
+	if kube.readRoutesFromGatewayAPI() {
+		return kube.WatchGatewayHTTPRoutes(ctx, namespace, metaFilter)
+	}
 	if kube.UseNetworkingV1Ingress {
 		return kube.WatchHandlers.IngressesNetworkingV1.Watch(ctx, namespace, metaFilter)
-	} else {
-		return kube.WatchHandlers.IngressesV1Beta1.Watch(ctx, namespace, metaFilter)
 	}
+	return kube.WatchHandlers.IngressesV1Beta1.Watch(ctx, namespace, metaFilter)
 }
 
 func (kube *Kubernetes) WatchGatewayHTTPRoutes(ctx context.Context, namespace string, metaFilter filter.Meta) (*pmWatch.Handler, error) {

--- a/service/internal/kubernetes/route.go
+++ b/service/internal/kubernetes/route.go
@@ -362,12 +362,8 @@ func (kube *Kubernetes) upsertExtensionsV1Ingress(ctx context.Context, route *en
 	return routeResourceResult{route: routeFromIngress, status: routeStatusUpdated}
 }
 
-func (kube *Kubernetes) readRoutesFromGatewayAPI() bool {
-	return kube.GatewaySystem.IsGatewayAPIEnabled()
-}
-
 func (kube *Kubernetes) GetRoute(ctx context.Context, resourceName string, namespace string) (*entity.Route, error) {
-	if kube.readRoutesFromGatewayAPI() {
+	if kube.GatewaySystem.IsGatewayAPIEnabled() {
 		httpRoute, err := GetWrapper(ctx, resourceName, namespace, kube.getGatewayV1Client().HTTPRoutes(namespace).Get,
 			kube.Cache.HTTPRoute, entity.WrapHTTPRoute)
 		if err != nil || httpRoute == nil {
@@ -499,7 +495,7 @@ func (kube *Kubernetes) deleteRouteLegacyIngress(ctx context.Context, routeName,
 }
 
 func (kube *Kubernetes) GetRouteList(ctx context.Context, namespace string, filter filter.Meta) ([]entity.Route, error) {
-	if kube.readRoutesFromGatewayAPI() {
+	if kube.GatewaySystem.IsGatewayAPIEnabled() {
 		httpRoutes, err := ListWrapper(ctx, filter, kube.getGatewayV1Client().HTTPRoutes(namespace).List, kube.Cache.HTTPRoute,
 			func(listObj *gatewayv1.HTTPRouteList) (result []entity.HttpRoute) {
 				for _, item := range listObj.Items {
@@ -572,14 +568,14 @@ func (kube *Kubernetes) GetGrpcRouteList(ctx context.Context, namespace string, 
 }
 
 func (kube *Kubernetes) GetBadRouteLists(ctx context.Context) (map[string][]string, error) {
-	if kube.readRoutesFromGatewayAPI() {
+	if kube.GatewaySystem.IsGatewayAPIEnabled() {
 		return map[string][]string{}, nil
 	}
 	return kube.BadResources.Routes.ToSliceMap(), nil
 }
 
 func (kube *Kubernetes) WatchRoutes(ctx context.Context, namespace string, metaFilter filter.Meta) (*pmWatch.Handler, error) {
-	if kube.readRoutesFromGatewayAPI() {
+	if kube.GatewaySystem.IsGatewayAPIEnabled() {
 		return kube.WatchGatewayHTTPRoutes(ctx, namespace, metaFilter)
 	}
 	if kube.UseNetworkingV1Ingress {

--- a/service/internal/kubernetes/route_test.go
+++ b/service/internal/kubernetes/route_test.go
@@ -262,7 +262,7 @@ func Test_UpdateOrCreateRoute_Update_Success(t *testing.T) {
 	assertions.Equal(ingress.Spec.IngressClassName, route.Spec.IngressClassName)
 }
 
-func Test_GetRoute_Success(t *testing.T) {
+func Test_GetRoute_LegacyIngress_ReadsIngress(t *testing.T) {
 	assertions := require.New(t)
 	ctx := context.Background()
 
@@ -285,6 +285,7 @@ func Test_GetRoute_Success(t *testing.T) {
 	kubeClientSet := fake.NewClientset(&ingress)
 	cert_client := &certClient.Clientset{}
 	kubeClient, _ := NewTestKubernetesClient(testNamespace1, &backend.KubernetesApi{KubernetesInterface: kubeClientSet, CertmanagerInterface: cert_client})
+	kubeClient.GatewaySystem.Type = LegacyIngress
 
 	kubeClient.Cache = cache.NewTestResourcesCache()
 	ok, err := kubeClient.Cache.Ingresses.Set(ctx, *entity.RouteFromIngress(&ingress))
@@ -295,6 +296,30 @@ func Test_GetRoute_Success(t *testing.T) {
 	assertions.Nil(err)
 	assertions.NotNil(route)
 	assertions.Equal(testIngress, route.Name)
+}
+
+func Test_GetRoute_GatewayApiDefault_ReadsHTTPRoute(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+
+	httpRoute := dualModeTestRoute().ToHTTPRoute("gateway-system", "default-external-gateway")
+	kubeClientSet := fake.NewClientset()
+	gwClient := gatewayclientfake.NewSimpleClientset(httpRoute)
+	kubeClient, err := NewKubernetesClientBuilder().
+		WithNamespace(testNamespace1).
+		WithClient(&backend.KubernetesApi{
+			KubernetesInterface:  kubeClientSet,
+			CertmanagerInterface: &certClient.Clientset{},
+			GatewayInterface:     gwClient,
+		}).
+		WithGatewaySystemType(GatewayApiDefault).
+		Build()
+	assertions.NoError(err)
+
+	route, err := kubeClient.GetRoute(ctx, testIngress, testNamespace1)
+	assertions.NoError(err)
+	assertions.NotNil(route)
+	assertions.Equal(httpRoute.Name, route.Name)
 }
 
 func Test_GetRouteFromCache_UseNetworkingV1Ingress_Success(t *testing.T) {

--- a/service/internal/kubernetes/route_test.go
+++ b/service/internal/kubernetes/route_test.go
@@ -323,6 +323,49 @@ func Test_GetRoute_GatewayApiDefault_ReadsHTTPRoute(t *testing.T) {
 	assertions.Equal(httpRoute.Name, route.Name)
 }
 
+func Test_GetRoute_DualMode_IgnoresIngress(t *testing.T) {
+	assertions := require.New(t)
+	ctx := context.Background()
+
+	httpRoute := dualModeTestRoute().ToHTTPRoute("gateway-system", "default-external-gateway")
+	ingress := GetIngress(map[string]any{
+		"metadata": map[string]string{
+			"name":      testIngress,
+			"namespace": testNamespace1,
+		},
+		"spec": map[string]any{
+			"rules": []map[string]any{{
+				"host": "legacy-only.example.com",
+				"http": map[string]any{
+					"paths": []map[string]any{{
+						"path": "legacy-path",
+						"backend": map[string]any{
+							"serviceName": "legacy-service",
+							"servicePort": "9090",
+						},
+					}},
+				},
+			}},
+		},
+	})
+	kubeClient, err := NewKubernetesClientBuilder().
+		WithNamespace(testNamespace1).
+		WithClient(&backend.KubernetesApi{
+			KubernetesInterface:  fake.NewClientset(&ingress),
+			CertmanagerInterface: &certClient.Clientset{},
+			GatewayInterface:     gatewayclientfake.NewSimpleClientset(httpRoute),
+		}).
+		WithGatewaySystemType(LegacyIngress + "," + GatewayApiDefault).
+		Build()
+	assertions.NoError(err)
+
+	route, err := kubeClient.GetRoute(ctx, testIngress, testNamespace1)
+	assertions.NoError(err)
+	assertions.NotNil(route)
+	expected := entity.RouteFromHTTPRoute(httpRoute)
+	assertions.Equal(expected.Spec.Host, route.Spec.Host)
+	assertions.NotEqual("legacy-only.example.com", route.Spec.Host)
+}
 func Test_GetRouteFromCache_UseNetworkingV1Ingress_Success(t *testing.T) {
 	assertions := require.New(t)
 	ctx := context.Background()


### PR DESCRIPTION
# What does this MR do?

This MR fixes these functions:

- GetRouteList
- GetRoute
- WatchRoutes

 so that they check in what mode service was deployed and gives priority to gateway_system_type with value gateway-api-default.

# Why these changes were made
They were made for case when both httproute and ingress with the same name exist and to not confuse them and to avoid breaking the contract it was decided to return only on type of routes depending on the gateway_system_type  with priority given to httproutes.